### PR TITLE
refactor(config): unify LLM config shape across agent and MCP modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The config file written by `astra setup --agent` has an `agent` section with `ll
   "createdAt": "2026-05-05T00:00:00.000Z",
   "mode": "agent",
   "agent": {
-    "llm": { "provider": "groq", "model": "llama-3.3-70b-versatile" },
+    "llm": { "provider": "groq", "model": "llama-3.3-70b-versatile", "apiKeyEnv": "GROQ_API_KEY" },
     "target": {
       "name": "My Support Bot",
       "description": "A customer support chatbot with access to user booking data and PII.",
@@ -124,7 +124,7 @@ For a local script target (stdin/stdout adapter):
 
 Astra connects to your MCP server, calls `tools/list`, generates attacks per tool, fires real `tools/call` requests, and judges the responses.
 
-The config file written by `astra setup --mcp` has an `mcp` section with `server` and `model`:
+The config file written by `astra setup --mcp` has an `mcp` section with `server` and `llm`:
 
 ```json
 {
@@ -137,7 +137,7 @@ The config file written by `astra setup --mcp` has an `mcp` section with `server
       "command": "node",
       "args": ["dist/index.js"]
     },
-    "model": { "provider": "openai", "model": "gpt-4o-mini", "apiKeyEnv": "OPENAI_API_KEY" }
+    "llm": { "provider": "openai", "model": "gpt-4o-mini", "apiKeyEnv": "OPENAI_API_KEY" }
   }
 }
 ```
@@ -151,7 +151,7 @@ For a remote MCP server over HTTP/SSE:
     "url": "https://your-mcp-server.example.com/mcp",
     "headers": { "Authorization": "Bearer <token>" }
   },
-  "model": { "provider": "openai", "model": "gpt-4o-mini", "apiKeyEnv": "OPENAI_API_KEY" }
+  "llm": { "provider": "openai", "model": "gpt-4o-mini", "apiKeyEnv": "OPENAI_API_KEY" }
 }
 ```
 
@@ -186,11 +186,7 @@ export ANTHROPIC_API_KEY=sk-ant-...
 export GOOGLE_GENERATIVE_AI_API_KEY=...
 ```
 
-You can also embed the key directly in the config file (not recommended for shared configs):
-
-```json
-"llm": { "provider": "groq", "apiKey": "gsk_..." }
-```
+Both agent and MCP configs use `apiKeyEnv` — a reference to an environment variable name, not the key value itself. This keeps secrets out of config files.
 
 Never commit API keys. Add `.astra/` to `.gitignore`.
 

--- a/src/agent/cli/src/commands/init.ts
+++ b/src/agent/cli/src/commands/init.ts
@@ -8,7 +8,7 @@ const SAMPLE_CONFIG = `{
     "llm": {
       "provider": "openai",
       "model": "gpt-4o-mini",
-      "apiKey": ""
+      "apiKeyEnv": "OPENAI_API_KEY"
     },
     "target": {
       "name": "My AI Agent",

--- a/src/agent/cli/src/commands/run.ts
+++ b/src/agent/cli/src/commands/run.ts
@@ -23,7 +23,6 @@ export async function runAgentAttacksFromFile(opts: {
   targetScript?: string;
   outputDir?: string;
   concurrency?: string;
-  apiKey?: string;
 }): Promise<{ html: string; json: string }> {
   let promptsFile: PromptsFile;
   const inputPath = path.resolve(opts.input);
@@ -37,10 +36,7 @@ export async function runAgentAttacksFromFile(opts: {
   }
 
   const { target, attacks } = promptsFile;
-  const llm = {
-    ...promptsFile.llm,
-    ...(opts.apiKey ? { apiKey: opts.apiKey as string } : {}),
-  };
+  const llm = promptsFile.llm;
 
   if (!attacks || attacks.length === 0) {
     throw new Error("No attack entries found in the prompts file. Run `astra generate` first.");
@@ -230,7 +226,6 @@ export function registerRunCommand(program: Command) {
     )
     .option("--output-dir <path>", "Directory to write HTML/JSON reports", ".astra/reports")
     .option("--concurrency <n>", "Max parallel attacks (default 1 — sequential)", "1")
-    .option("--api-key <key>", "LLM API key (overrides the key stored in the prompts file)")
     .action(async (opts) => {
       try {
         const paths = await runAgentAttacksFromFile({
@@ -238,7 +233,6 @@ export function registerRunCommand(program: Command) {
           targetScript: opts.targetScript,
           outputDir: opts.outputDir,
           concurrency: opts.concurrency,
-          apiKey: opts.apiKey,
         });
         console.log(`\nReports:`);
         console.log(`  HTML: ${paths.html}`);

--- a/src/agent/cli/src/commands/setup.ts
+++ b/src/agent/cli/src/commands/setup.ts
@@ -145,26 +145,14 @@ async function collectLlmConfig(): Promise<LlmConfig> {
     });
   }
 
-  // API key — offer to reuse from env var if already set
-  const envVar = PROVIDER_ENV_VARS[provider];
-  const existingKey = process.env[envVar];
-  let apiKey: string;
+  const defaultEnvVar = PROVIDER_ENV_VARS[provider];
+  const apiKeyEnv = await input({
+    message: "Env var name for API key:",
+    default: defaultEnvVar,
+    validate: (v) => v.trim() !== "" || "Env var name is required",
+  });
 
-  if (existingKey) {
-    const useEnv = await confirm({
-      message: `Found ${envVar} in environment. Use it?`,
-      default: true,
-    });
-    apiKey = useEnv ? existingKey : await password({ message: "API key:", mask: "*" });
-  } else {
-    apiKey = await password({
-      message: `API key (or set ${envVar} env var):`,
-      mask: "*",
-      validate: (v) => v.trim() !== "" || "API key is required",
-    });
-  }
-
-  return { provider, model, apiKey, baseURL };
+  return { provider, model, apiKeyEnv: apiKeyEnv.trim(), baseURL };
 }
 
 async function runInteractiveWizard(
@@ -335,8 +323,7 @@ function extractAgentSetupPayload(parsed: unknown): SetupConfigFile {
 
 async function loadConfigFile(
   configPath: string,
-  catalog: Awaited<ReturnType<typeof loadSkillCatalog>>,
-  apiKeyOverride?: string
+  catalog: Awaited<ReturnType<typeof loadSkillCatalog>>
 ): Promise<CollectedAnswers> {
   const { suites: SUITES } = catalog;
   const EVALUATOR_IDS = getEvaluatorIdSet(catalog);
@@ -358,21 +345,11 @@ async function loadConfigFile(
     selectedEvaluatorIds = cfg.selection.evaluators;
   }
 
-  // Resolve LLM — --api-key flag > config file > env var
   const provider: ProviderName = (cfg.llm?.provider as ProviderName) ?? "groq";
-  const envVar = PROVIDER_ENV_VARS[provider];
-  const apiKey = apiKeyOverride?.trim() || cfg.llm?.apiKey?.trim() || process.env[envVar] || "";
-  if (!apiKey) {
-    throw new Error(
-      `No API key found for provider "${provider}". ` +
-      `Pass --api-key, set llm.apiKey in the config file, or export ${envVar}.`
-    );
-  }
-
   const llm: LlmConfig = {
     provider,
     model: cfg.llm?.model ?? PROVIDER_DEFAULTS[provider],
-    apiKey,
+    apiKeyEnv: cfg.llm?.apiKeyEnv ?? PROVIDER_ENV_VARS[provider],
     baseURL: cfg.llm?.baseURL,
   };
 
@@ -400,7 +377,6 @@ export function registerSetupCommand(program: Command) {
     )
     .option("--config <path>", "Path to a JSON or YAML setup config file (skips interactive prompts)")
     .option("--output-dir <path>", "Directory to write the prompts JSON file", ".")
-    .option("--api-key <key>", "LLM API key (overrides config file and environment variable)")
     .action(async (opts) => {
       let answers: CollectedAnswers;
       try {
@@ -408,12 +384,11 @@ export function registerSetupCommand(program: Command) {
         if (opts.config) {
           const resolvedPath = path.resolve(opts.config);
           console.log(`\nLoading config from: ${resolvedPath}`);
-          answers = await loadConfigFile(opts.config, catalog, opts.apiKey);
+          answers = await loadConfigFile(opts.config, catalog);
           logTelemetryFromConfig(answers.telemetry);
           console.log(`Starting setup (attack prompt generation)…`);
         } else {
           answers = await runInteractiveWizard(catalog);
-          if (opts.apiKey) answers.llm.apiKey = opts.apiKey;
         }
       } catch (err: unknown) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -569,11 +544,10 @@ export function registerSetupCommand(program: Command) {
 export async function generateAgentAttacksFromConfig(opts: {
   configPath: string;
   outputPath: string;
-  apiKeyOverride?: string;
   configId?: string;
 }): Promise<string> {
   const catalog = await loadSkillCatalog();
-  const answers = await loadConfigFile(opts.configPath, catalog, opts.apiKeyOverride);
+  const answers = await loadConfigFile(opts.configPath, catalog);
 
   const { llm, target, selectedEvaluatorIds, telemetry, turnMode, turns } = answers;
   const model = createModel(llm);

--- a/src/agent/cli/src/providers/factory.ts
+++ b/src/agent/cli/src/providers/factory.ts
@@ -22,7 +22,9 @@ export const PROVIDER_ENV_VARS: Record<ProviderName, string> = {
 };
 
 export function createModel(llm: LlmConfig): LanguageModel {
-  const { provider, model, apiKey, baseURL } = llm;
+  const apiKey = process.env[llm.apiKeyEnv]?.trim();
+  if (!apiKey) throw new Error(`Missing env var: ${llm.apiKeyEnv}`);
+  const { provider, model, baseURL } = llm;
 
   switch (provider) {
     case "openai":

--- a/src/agent/cli/src/wizard/unifiedSetupWizard.ts
+++ b/src/agent/cli/src/wizard/unifiedSetupWizard.ts
@@ -1,6 +1,6 @@
 import { input, select, confirm } from "@inquirer/prompts";
 import type { SetupConfigFile, ProviderName, TargetConfig } from "@astra/core/config/types";
-import { PROVIDER_DEFAULTS } from "@astra/core/providers/factory";
+import { PROVIDER_DEFAULTS, PROVIDER_ENV_VARS } from "@astra/core/providers/factory";
 import { loadSkillCatalog } from "@astra/core/config/loadSkillCatalog";
 
 export function buildEmptyAgentSetupConfig(): SetupConfigFile {
@@ -8,7 +8,7 @@ export function buildEmptyAgentSetupConfig(): SetupConfigFile {
     llm: {
       provider: "openai",
       model: "gpt-4o-mini",
-      apiKey: "",
+      apiKeyEnv: "OPENAI_API_KEY",
     },
     target: {
       name: "My AI Agent",
@@ -132,7 +132,7 @@ export async function collectAgentSetupConfigInteractive(): Promise<SetupConfigF
   });
 
   return {
-    llm: { provider, model: model.trim(), apiKey: "" },
+    llm: { provider, model: model.trim(), apiKeyEnv: PROVIDER_ENV_VARS[provider] },
     target,
     selection: { mode: "suite", suite: suiteId },
     turnMode,

--- a/src/agent/core/src/config/types.ts
+++ b/src/agent/core/src/config/types.ts
@@ -276,8 +276,8 @@ export type ProviderName = "openai" | "anthropic" | "groq" | "google" | "other";
 export interface LlmConfig {
   provider: ProviderName;
   model: string;
-  apiKey: string;   // stored in prompts file — warn user to gitignore
-  baseURL?: string; // only for "other"
+  apiKeyEnv: string; // env var name, resolved at runtime
+  baseURL?: string;  // only for "other"
 }
 
 export interface TargetConfig {
@@ -366,7 +366,7 @@ export interface InlineSetupConfig {
   llm?: {
     provider?: ProviderName;
     model?: string;
-    apiKey?: string;
+    apiKeyEnv?: string;
     baseURL?: string;
   };
   /**
@@ -393,7 +393,7 @@ export interface SetupConfigFile {
   llm?: {
     provider?: ProviderName;
     model?: string;
-    apiKey?: string;
+    apiKeyEnv?: string;
     baseURL?: string;
   };
   target: {

--- a/src/agent/core/src/providers/factory.ts
+++ b/src/agent/core/src/providers/factory.ts
@@ -22,7 +22,9 @@ export const PROVIDER_ENV_VARS: Record<ProviderName, string> = {
 };
 
 export function createModel(llm: LlmConfig): LanguageModel {
-  const { provider, model, apiKey, baseURL } = llm;
+  const apiKey = process.env[llm.apiKeyEnv]?.trim();
+  if (!apiKey) throw new Error(`Missing env var: ${llm.apiKeyEnv}`);
+  const { provider, model, baseURL } = llm;
 
   switch (provider) {
     case "openai":

--- a/src/agent/core/src/report/generateReport.ts
+++ b/src/agent/core/src/report/generateReport.ts
@@ -620,10 +620,11 @@ export async function generateReport(
 </html>`;
 
   // --- write files ---
-  await mkdir(outputDir, { recursive: true });
+  const reportDir = path.join(outputDir, `report-${reportId}`);
+  await mkdir(reportDir, { recursive: true });
 
-  const htmlPath = path.join(outputDir, `${reportId}.html`);
-  const jsonPath = path.join(outputDir, `${reportId}.json`);
+  const htmlPath = path.join(reportDir, `report.html`);
+  const jsonPath = path.join(reportDir, `report.json`);
 
   await writeFile(htmlPath, html, "utf8");
   await writeFile(jsonPath, JSON.stringify(jsonData, null, 2), "utf8");

--- a/src/agent/mcp/src/core/run.ts
+++ b/src/agent/mcp/src/core/run.ts
@@ -16,7 +16,6 @@ import { newOtelTraceId } from "@astra/core/lib/tracePropagation";
 
 export interface RunOptions {
   inputPath: string;
-  apiKey?: string;
   outputDir?: string;
   /** If set, run attacks against this script (stdin JSON, stdout JSON response). */
   targetScript?: string;
@@ -49,7 +48,7 @@ export interface RunSummary {
 }
 
 export async function runScan(opts: RunOptions): Promise<RunSummary> {
-  const { inputPath, apiKey: apiKeyOverride, outputDir = ".astra/reports", targetScript: targetScriptOpt } = opts;
+  const { inputPath, outputDir = ".astra/reports", targetScript: targetScriptOpt } = opts;
 
   const raw = await readFile(path.resolve(inputPath), "utf8");
   const promptsFile = JSON.parse(raw) as PromptsFile;
@@ -81,10 +80,7 @@ export async function runScan(opts: RunOptions): Promise<RunSummary> {
     );
   }
 
-  const llm = {
-    ...promptsFile.llm,
-    ...(apiKeyOverride?.trim() ? { apiKey: apiKeyOverride.trim() } : {}),
-  };
+  const llm = promptsFile.llm;
 
   const model = createModel(llm);
   const endpoint = target.endpoint ?? "";

--- a/src/agent/mcp/src/core/setup.ts
+++ b/src/agent/mcp/src/core/setup.ts
@@ -25,7 +25,6 @@ import type {
 
 export interface SetupOptions {
   configPath: string;
-  apiKey?: string;
   outputDir?: string;
 }
 
@@ -44,7 +43,7 @@ export interface SetupResult {
 }
 
 export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
-  const { configPath, apiKey: apiKeyOverride, outputDir = "." } = opts;
+  const { configPath, outputDir = "." } = opts;
 
   const raw = await readFile(path.resolve(configPath), "utf8");
   const ext = path.extname(configPath).toLowerCase();
@@ -68,21 +67,11 @@ export async function runSetup(opts: SetupOptions): Promise<SetupResult> {
     selectedEvaluatorIds = cfg.selection.evaluators;
   }
 
-  // Resolve API key: argument > config file > env var
   const provider: ProviderName = (cfg.llm?.provider as ProviderName) ?? "groq";
-  const envVar = PROVIDER_ENV_VARS[provider];
-  const apiKey = apiKeyOverride?.trim() || cfg.llm?.apiKey?.trim() || process.env[envVar] || "";
-  if (!apiKey) {
-    throw new Error(
-      `No API key for provider "${provider}". ` +
-      `Pass apiKey in the tool call, set llm.apiKey in the config, or set env var ${envVar}.`
-    );
-  }
-
   const llm: LlmConfig = {
     provider,
     model: cfg.llm?.model ?? PROVIDER_DEFAULTS[provider],
-    apiKey,
+    apiKeyEnv: cfg.llm?.apiKeyEnv ?? PROVIDER_ENV_VARS[provider],
     baseURL: cfg.llm?.baseURL,
   };
 
@@ -129,19 +118,10 @@ export async function runSetupInline(
   }
 
   const provider: ProviderName = (inline.llm?.provider as ProviderName) ?? "groq";
-  const envVar = PROVIDER_ENV_VARS[provider];
-  const apiKey = inline.llm?.apiKey?.trim() || process.env[envVar] || "";
-  if (!apiKey) {
-    throw new Error(
-      `No API key for provider "${provider}". ` +
-      `Pass llm.apiKey in the tool call or set env var ${envVar}.`
-    );
-  }
-
   const llm: LlmConfig = {
     provider,
     model: inline.llm?.model ?? PROVIDER_DEFAULTS[provider],
-    apiKey,
+    apiKeyEnv: inline.llm?.apiKeyEnv ?? PROVIDER_ENV_VARS[provider],
     baseURL: inline.llm?.baseURL,
   };
 

--- a/src/agent/mcp/src/index.ts
+++ b/src/agent/mcp/src/index.ts
@@ -163,7 +163,7 @@ server.tool(
       .optional()
       .describe(
         "LLM provider astra uses to generate attack prompts and judge responses. " +
-        "Defaults to 'groq'. The corresponding API key env var must be set, or pass llm_api_key."
+        "Defaults to 'groq'. The corresponding API key env var must be set (or pass llm_api_key_env to specify the var name)."
       ),
 
     llm_model: z
@@ -171,12 +171,12 @@ server.tool(
       .optional()
       .describe("Model name for the LLM (e.g. 'llama-3.3-70b-versatile'). Uses provider default if omitted."),
 
-    llm_api_key: z
+    llm_api_key_env: z
       .string()
       .optional()
       .describe(
-        "API key for the attack/judge LLM. Overrides env vars " +
-        "(GROQ_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY, GOOGLE_GENERATIVE_AI_API_KEY)."
+        "Name of the environment variable holding the API key for the attack/judge LLM " +
+        "(e.g. 'GROQ_API_KEY'). Defaults to the standard env var for the chosen provider."
       ),
 
     // ── Langfuse / traces ───────────────────────────────────────────────────
@@ -258,7 +258,7 @@ server.tool(
       evaluator_ids,
       llm_provider,
       llm_model,
-      llm_api_key,
+      llm_api_key_env,
       use_langfuse = false,
       langfuse_lookback_hours,
       langfuse_trace_ids,
@@ -345,11 +345,11 @@ server.tool(
               ...(session_id_field ? { sessionIdField: session_id_field } : {}),
             },
             selection,
-            llm: llm_provider || llm_model || llm_api_key
+            llm: llm_provider || llm_model || llm_api_key_env
               ? {
                   ...(llm_provider ? { provider: llm_provider } : {}),
                   ...(llm_model ? { model: llm_model } : {}),
-                  ...(llm_api_key ? { apiKey: llm_api_key } : {}),
+                  ...(llm_api_key_env ? { apiKeyEnv: llm_api_key_env } : {}),
                 }
               : undefined,
             useLangfuse: use_langfuse,
@@ -362,7 +362,6 @@ server.tool(
       } else {
         result = await runSetup({
           configPath: config_path!,
-          apiKey: llm_api_key,
           outputDir: output_dir,
         });
       }
@@ -422,24 +421,16 @@ server.tool(
     input_path: z
       .string()
       .describe("Path to the astra-prompts-*.json file produced by astra_setup."),
-    api_key: z
-      .string()
-      .optional()
-      .describe(
-        "LLM API key for judging responses (overrides the key stored in the prompts file). " +
-        "Useful when running in CI without committing keys."
-      ),
     output_dir: z
       .string()
       .optional()
       .default(".astra/reports")
       .describe("Directory where HTML and JSON reports will be written. Defaults to .astra/reports."),
   },
-  async ({ input_path, api_key, output_dir }) => {
+  async ({ input_path, output_dir }) => {
     try {
       const result = await runScan({
         inputPath: input_path,
-        apiKey: api_key,
         outputDir: output_dir,
       });
 

--- a/src/mcp/attacks/generatePlan.ts
+++ b/src/mcp/attacks/generatePlan.ts
@@ -111,7 +111,7 @@ async function generateAttacksForEvaluator(args: {
   ].join("\n");
 
   const raw = await chatCompletionJsonContent({
-    model: args.cfg.model,
+    model: args.cfg.llm,
     system,
     user,
   });
@@ -207,7 +207,7 @@ export async function generateAttackPlan(args: {
     toolsDigest: toolsDigest(args.tools),
     attacks: finalAttacks,
     server: args.cfg.server,
-    runModel: args.cfg.model,
+    runLlm: args.cfg.llm,
     attackerInstructions: args.cfg.attackerInstructions,
   };
 

--- a/src/mcp/attacks/planSchema.ts
+++ b/src/mcp/attacks/planSchema.ts
@@ -30,7 +30,7 @@ export const AttackPlanSchema = z.object({
   ),
   attacks: z.array(AttackScenarioSchema),
   server: McpServerConfigSchema.optional(),
-  runModel: ModelConfigSchema.optional(),
+  runLlm: ModelConfigSchema.optional(),
   attackerInstructions: z.string().optional(),
 });
 

--- a/src/mcp/commands/init.ts
+++ b/src/mcp/commands/init.ts
@@ -88,7 +88,7 @@ export function buildEmptyMcpSection() {
       args: ["dist/index.js"],
       env: {},
     },
-    model: {
+    llm: {
       provider: "groq" as const,
       model: "llama-3.3-70b-versatile",
       apiKeyEnv: "GROQ_API_KEY",
@@ -204,7 +204,7 @@ export async function collectMcpSectionInteractive() {
         })();
 
   log.start("Configuring model settings…");
-  const model = await promptModelConfig("attack");
+  const llm = await promptModelConfig("attack");
   log.success("Model settings captured.");
 
   const turnMode = await select<"single" | "multi">({
@@ -241,7 +241,7 @@ export async function collectMcpSectionInteractive() {
 
   const mcpSection = {
     server,
-    model,
+    llm,
     turnMode,
     ...(turns !== undefined ? { turns } : {}),
     ...(notes.trim() ? { notes: notes.trim() } : {}),

--- a/src/mcp/commands/run.ts
+++ b/src/mcp/commands/run.ts
@@ -58,9 +58,9 @@ export async function runMcpAttackPlan(opts: {
         "Re-run `astra generate --config <path>` to regenerate the plan with current config."
     );
   }
-  if (!plan.runModel) {
+  if (!plan.runLlm) {
     throw new Error(
-      "Attack plan is missing embedded run model config. " +
+      "Attack plan is missing embedded LLM config. " +
         "Re-run `astra generate --config <path>` to regenerate the plan with current config."
     );
   }
@@ -97,7 +97,7 @@ export async function runMcpAttackPlan(opts: {
           ? errorJudge(execResult.toolError!)
           : sanitizeJudgeResult(
               await judgeToolResponse({
-                model: plan.runModel,
+                model: plan.runLlm,
                 evaluator: criteria,
                 attackSummary: attack.summary,
                 toolName: execResult.toolName,
@@ -158,7 +158,7 @@ export async function runMcpAttackPlan(opts: {
               attack.summary,
               attack.suggestedToolName ?? "",
               (attack.suggestedToolArguments ?? {}) as Record<string, unknown>,
-              plan.runModel,
+              plan.runLlm,
               plan.attackerInstructions
             );
             overrideArgs = turnResult.args;
@@ -172,7 +172,7 @@ export async function runMcpAttackPlan(opts: {
             ? errorJudge(turnExec.toolError!)
             : sanitizeJudgeResult(
                 await judgeToolResponse({
-                  model: plan.runModel,
+                  model: plan.runLlm,
                   evaluator: criteria,
                   attackSummary: attack.summary,
                   toolName: turnExec.toolName,
@@ -253,7 +253,7 @@ export async function runMcpAttackPlan(opts: {
   } catch (runErr: unknown) {
     if (runResults.length > 0) {
       try {
-        let partialReport = buildReport({ plan, results: runResults, runModel: plan.runModel });
+        let partialReport = buildReport({ plan, results: runResults, runLlm: plan.runLlm });
         partialReport = enrichReportWithCriteria(
           partialReport,
           new Map(
@@ -276,7 +276,7 @@ export async function runMcpAttackPlan(opts: {
     await mcp.close().catch(() => undefined);
   }
 
-  let report = buildReport({ plan, results: runResults, runModel: plan.runModel });
+  let report = buildReport({ plan, results: runResults, runLlm: plan.runLlm });
   report = enrichReportWithCriteria(
     report,
     new Map(

--- a/src/mcp/config/schema.ts
+++ b/src/mcp/config/schema.ts
@@ -31,7 +31,7 @@ export const McpServerConfigSchema = z.discriminatedUnion("transport", [
 
 export const AstraMcpConfigSchema = z.object({
   server: McpServerConfigSchema,
-  model: ModelConfigSchema,
+  llm: ModelConfigSchema,
   /** "single" (default) fires one attack per scenario; "multi" runs adaptive multi-turn red-teaming. */
   turnMode: z.enum(["single", "multi"]).optional(),
   /** Number of adaptive turns per attack when turnMode is "multi" (default 3). */

--- a/src/mcp/report/buildReport.ts
+++ b/src/mcp/report/buildReport.ts
@@ -10,9 +10,9 @@ function modelLabel(model: ModelConfig): string {
 export function buildReport(args: {
   plan: AttackPlanWritten;
   results: AttackRunResult[];
-  runModel: ModelConfig;
+  runLlm: ModelConfig;
 }): RunReport {
-  const { plan, results, runModel } = args;
+  const { plan, results, runLlm } = args;
 
   // Group results by evaluatorId
   const byEvaluator = new Map<string, AttackRunResult[]>();
@@ -57,7 +57,7 @@ export function buildReport(args: {
     suiteId: plan.suiteId,
     serverSummary: plan.serverSummary,
     transport: plan.transport,
-    judgeModel: modelLabel(runModel),
+    judgeModel: modelLabel(runLlm),
     summary: {
       total,
       passed,

--- a/src/mcp/run/generateNextMcpAttackTurn.ts
+++ b/src/mcp/run/generateNextMcpAttackTurn.ts
@@ -45,7 +45,7 @@ export async function generateNextMcpAttackTurn(
   attackGoal: string,
   toolName: string,
   seedArguments: Record<string, unknown>,
-  model: ModelConfig,
+  llm: ModelConfig,
   attackerInstructions?: string
 ): Promise<AttackTurnResult> {
   const historyText = history.map((t, i) => {
@@ -77,7 +77,7 @@ export async function generateNextMcpAttackTurn(
     `Respond with ONLY a valid JSON object with "args" and "judgeHint" keys.`,
   ].join("\n");
 
-  const raw = await chatCompletionJsonContent({ model, system: ATTACKER_SYSTEM, user });
+  const raw = await chatCompletionJsonContent({ model: llm, system: ATTACKER_SYSTEM, user });
 
   try {
     const parsed = JSON.parse(raw) as { args?: Record<string, unknown>; judgeHint?: string | null };

--- a/src/types/astra-cli.d.ts
+++ b/src/types/astra-cli.d.ts
@@ -6,7 +6,6 @@ declare module "astra-cli" {
   export function generateAgentAttacksFromConfig(opts: {
     configPath: string;
     outputPath: string;
-    apiKeyOverride?: string;
     configId?: string;
   }): Promise<string>;
   export function runAgentAttacksFromFile(opts: {
@@ -14,6 +13,5 @@ declare module "astra-cli" {
     targetScript?: string;
     outputDir?: string;
     concurrency?: string;
-    apiKey?: string;
   }): Promise<{ html: string; json: string }>;
 }


### PR DESCRIPTION
- Rename `model` → `llm` in MCP config schema and all call sites
- Replace inline `apiKey` with `apiKeyEnv` (env var name) in both modes
- Remove --api-key CLI flags; keys now resolved exclusively from env
- Fix agent report output to use report-<id>/report.json|html subfolder
- Fix astra_setup MCP tool: llm_api_key param renamed to llm_api_key_env