### PR TITLE
Feat/mcp tool filtering

### DIFF
--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -21,6 +21,12 @@ export function registerGenerateCommand(program: Command): void {
     .option("--out <path>", "Override output path for attacks JSON (advanced)")
     .option("--mcp", "Force MCP mode (useful when config contains both blocks)")
     .option("--agent", "Force agent mode (useful when config contains both blocks)")
+    .option("--suite <id>", "Suite to use (overrides config; ignored if --evaluators is set)")
+    .option(
+      "--evaluators <ids...>",
+      "Specific evaluator IDs to run (highest priority, overrides --suite and config)"
+    )
+    .option("--no-tool-filter", "Disable automatic tool-relevance filtering")
     .action(
       async (opts: {
         config?: string;
@@ -28,6 +34,9 @@ export function registerGenerateCommand(program: Command): void {
         out?: string;
         mcp?: boolean;
         agent?: boolean;
+        suite?: string;
+        evaluators?: string[];
+        toolFilter: boolean;
       }) => {
         if (opts.env) loadEnvFromFlag(opts.env);
         await ensureAstraDirs();
@@ -68,6 +77,9 @@ export function registerGenerateCommand(program: Command): void {
             config: configPath,
             out: outPath,
             configId: cfg.configId,
+            suite: opts.suite,
+            evaluators: opts.evaluators,
+            toolFilter: opts.toolFilter,
           });
         } else {
           await generateAgentAttacksFromConfig({

--- a/cli/src/commands/mcp/setup.ts
+++ b/cli/src/commands/mcp/setup.ts
@@ -20,8 +20,11 @@ export async function runMcpGenerateAttackPlan(opts: {
   out: string;
   maxTools?: string;
   configId?: string;
+  suite?: string;
+  evaluators?: string[];
+  toolFilter?: boolean;
 }): Promise<string> {
-  const { config, out, maxTools, configId } = opts;
+  const { config, out, maxTools, configId, toolFilter } = opts;
 
   const configPath = await requireAstraMcpConfig(config);
   log.info(`Using config: ${configPath}`);
@@ -32,17 +35,91 @@ export async function runMcpGenerateAttackPlan(opts: {
   const evalIds = getEvaluatorIdSet(catalog);
   log.info(`Evaluator catalog: ${catalog.evaluators.length} definitions`);
 
-  const suite = catalog.suites.find((s) => s.id === DEFAULT_SUITE_ID);
-  if (!suite) {
-    throw new Error(`Suite "${DEFAULT_SUITE_ID}" not found (check skills/astra-setup/suites/).`);
+  // Priority: CLI --evaluators > CLI --suite > config evaluators > config suite > default
+  const cliEvaluators = opts.evaluators;
+  const cliSuite = opts.suite;
+  const cfgEvaluators = cfg.evaluators;
+  const cfgSuite = cfg.suite;
+
+  let resolvedEvaluatorIds: string[];
+  let resolvedSuiteId: string;
+
+  if (cliEvaluators && cliEvaluators.length > 0) {
+    // Explicit evaluator list from CLI (highest priority)
+    const unknown = cliEvaluators.filter((id) => !evalIds.has(id));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Unknown evaluator(s): ${unknown.join(", ")}. Run 'astra list-evaluators' to see available IDs.`
+      );
+    }
+    resolvedEvaluatorIds = cliEvaluators;
+    resolvedSuiteId = "custom";
+    log.success(
+      `Using ${resolvedEvaluatorIds.length} evaluators (from --evaluators): ${resolvedEvaluatorIds.join(", ")}`
+    );
+  } else if (cliSuite) {
+    // Suite from CLI flag
+    const suite = catalog.suites.find((s) => s.id === cliSuite);
+    if (!suite) {
+      const available = catalog.suites.map((s) => s.id).join(", ");
+      throw new Error(`Suite "${cliSuite}" not found. Available: ${available}`);
+    }
+    const missing = suite.evaluatorIds.filter((id) => !evalIds.has(id));
+    if (missing.length > 0) {
+      throw new Error(`Suite "${suite.id}" references missing evaluators: ${missing.join(", ")}`);
+    }
+    resolvedEvaluatorIds = suite.evaluatorIds;
+    resolvedSuiteId = suite.id;
+    log.success(
+      `Suite "${suite.id}" ready (${suite.evaluatorIds.length} evaluators: ${suite.evaluatorIds.join(", ")})`
+    );
+  } else if (cfgEvaluators && cfgEvaluators.length > 0) {
+    // Explicit evaluator list from config
+    const unknown = cfgEvaluators.filter((id) => !evalIds.has(id));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Config references unknown evaluator(s): ${unknown.join(", ")}. Run 'astra list-evaluators' to see available IDs.`
+      );
+    }
+    resolvedEvaluatorIds = cfgEvaluators;
+    resolvedSuiteId = "custom";
+    log.success(
+      `Using ${resolvedEvaluatorIds.length} evaluators (from config): ${resolvedEvaluatorIds.join(", ")}`
+    );
+  } else if (cfgSuite) {
+    // Suite from config
+    const suite = catalog.suites.find((s) => s.id === cfgSuite);
+    if (!suite) {
+      const available = catalog.suites.map((s) => s.id).join(", ");
+      throw new Error(`Suite "${cfgSuite}" not found. Available: ${available}`);
+    }
+    const missing = suite.evaluatorIds.filter((id) => !evalIds.has(id));
+    if (missing.length > 0) {
+      throw new Error(`Suite "${suite.id}" references missing evaluators: ${missing.join(", ")}`);
+    }
+    resolvedEvaluatorIds = suite.evaluatorIds;
+    resolvedSuiteId = suite.id;
+    log.success(
+      `Suite "${suite.id}" ready (${suite.evaluatorIds.length} evaluators: ${suite.evaluatorIds.join(", ")})`
+    );
+  } else {
+    // Default suite
+    const suite = catalog.suites.find((s) => s.id === DEFAULT_SUITE_ID);
+    if (!suite) {
+      throw new Error(
+        `Default suite "${DEFAULT_SUITE_ID}" not found (check skills/mcp-redteaming/suites/).`
+      );
+    }
+    const missing = suite.evaluatorIds.filter((id) => !evalIds.has(id));
+    if (missing.length > 0) {
+      throw new Error(`Suite "${suite.id}" references missing evaluators: ${missing.join(", ")}`);
+    }
+    resolvedEvaluatorIds = suite.evaluatorIds;
+    resolvedSuiteId = suite.id;
+    log.success(
+      `Suite "${suite.id}" ready (${suite.evaluatorIds.length} evaluators: ${suite.evaluatorIds.join(", ")})`
+    );
   }
-  const missing = suite.evaluatorIds.filter((id) => !evalIds.has(id));
-  if (missing.length > 0) {
-    throw new Error(`Suite "${suite.id}" references missing evaluators: ${missing.join(", ")}`);
-  }
-  log.success(
-    `Suite "${suite.id}" ready (${suite.evaluatorIds.length} evaluators: ${suite.evaluatorIds.join(", ")})`
-  );
 
   log.start("Connecting to MCP server (stdio or URL)…");
   const mcp = await connectMcpClient(cfg.server);
@@ -72,7 +149,7 @@ export async function runMcpGenerateAttackPlan(opts: {
   }
 
   const evaluatorDocs = [];
-  for (const id of suite.evaluatorIds) {
+  for (const id of resolvedEvaluatorIds) {
     evaluatorDocs.push(await loadEvaluatorDoc(id));
   }
 
@@ -82,10 +159,11 @@ export async function runMcpGenerateAttackPlan(opts: {
   }
   const plan = await generateAttackPlan({
     cfg,
-    suiteId: suite.id,
+    suiteId: resolvedSuiteId,
     tools,
     evaluatorDocs,
     turns: cfg.turnMode === "multi" ? (cfg.turns ?? 3) : undefined,
+    toolFilter,
   });
 
   (plan as unknown as Record<string, unknown>).mode = "mcp";
@@ -117,10 +195,33 @@ export function registerSetupCommand(program: Command) {
       "--max-tools <n>",
       "Limit to the first N tools from tools/list (useful for rate-limited LLMs)"
     )
+    .option("--suite <id>", "Suite to use (overrides config; ignored if --evaluators is set)")
+    .option(
+      "--evaluators <ids...>",
+      "Specific evaluator IDs (highest priority, overrides --suite and config)"
+    )
+    .option(
+      "--no-tool-filter",
+      "Disable automatic tool-relevance filtering (test every tool against every evaluator)"
+    )
     .action(
-      async ({ config, out, maxTools }: { config?: string; out: string; maxTools?: string }) => {
+      async (rawOpts: {
+        config?: string;
+        out: string;
+        maxTools?: string;
+        suite?: string;
+        evaluators?: string[];
+        toolFilter: boolean;
+      }) => {
         try {
-          await runMcpGenerateAttackPlan({ config, out, maxTools });
+          await runMcpGenerateAttackPlan({
+            config: rawOpts.config,
+            out: rawOpts.out,
+            maxTools: rawOpts.maxTools,
+            suite: rawOpts.suite,
+            evaluators: rawOpts.evaluators,
+            toolFilter: rawOpts.toolFilter,
+          });
         } catch (err: unknown) {
           const msg = err instanceof Error ? err.message : String(err);
           log.error(msg);

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -124,6 +124,8 @@ export function registerRunCommand(program: Command): void {
           console.log(`  HTML: ${paths.html}`);
           console.log(`  JSON: ${paths.json}\n`);
         }
+
+        process.exit(0);
       }
     );
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -27,6 +27,9 @@ registerGenerateCommand(program);
 registerRunCommand(program);
 
 main().catch((err: unknown) => {
+  if (err instanceof Error && err.name === "ExitPromptError") {
+    process.exit(0);
+  }
   const message = err instanceof Error ? err.stack || err.message : String(err);
   console.error(message);
   process.exitCode = 1;

--- a/core/src/attacks/generatePlan.ts
+++ b/core/src/attacks/generatePlan.ts
@@ -143,7 +143,84 @@ async function generateAttacksForEvaluator(args: {
     throw new Error(`LLM JSON missing attacks[] for evaluator "${args.evaluatorDoc.id}"`);
   }
 
-  return z.array(AttackScenarioSchema).parse(attacksUnknown);
+  // Filter out malformed entries (null, undefined, or missing required fields) before parsing.
+  const cleaned = attacksUnknown.filter(
+    (item): item is Record<string, unknown> =>
+      item != null && typeof item === "object" && "id" in item && "summary" in item
+  );
+
+  return z.array(AttackScenarioSchema).parse(cleaned);
+}
+
+/**
+ * Ask the LLM which tools are relevant for each evaluator.
+ * Returns a map: evaluatorId → tool names. Filters out irrelevant pairs
+ * to dramatically reduce token usage and attack count for large MCPs.
+ */
+async function computeToolRelevanceMap(args: {
+  cfg: AstraMcpConfig;
+  tools: ToolInfo[];
+  evaluatorDocs: EvaluatorDoc[];
+}): Promise<Record<string, string[]>> {
+  const toolSummaries = args.tools.map((t) => ({
+    name: t.name,
+    description: t.description ?? "(no description)",
+  }));
+
+  const evaluatorSummaries = args.evaluatorDocs.map((e) => ({
+    id: e.id,
+    name: e.name,
+  }));
+
+  const system = [
+    "You are a security expert. Given a list of MCP tools and security evaluator categories,",
+    "determine which tools are RELEVANT for each evaluator.",
+    "",
+    "A tool is relevant if it could plausibly exhibit the vulnerability that the evaluator checks for.",
+    "For example: a tool that fetches URLs is relevant for SSRF but not for secret-exposure.",
+    "",
+    "Return ONLY valid JSON (no markdown, no prose) matching this exact shape:",
+    '{"relevance":{"evaluator-id":["tool1","tool2"],...}}',
+    "",
+    "Rules:",
+    "- Every evaluator MUST appear as a key, even if its array is empty.",
+    "- Tool names must exactly match the TOOLS list.",
+    "- Include at least 1 tool per evaluator when any reasonable connection exists.",
+    "- When in doubt, INCLUDE the tool (err on the side of coverage).",
+  ].join("\n");
+
+  const user = [
+    "TOOLS:",
+    JSON.stringify(toolSummaries, null, 2),
+    "",
+    "EVALUATORS:",
+    JSON.stringify(evaluatorSummaries, null, 2),
+  ].join("\n");
+
+  const raw = await chatCompletionJsonContent({
+    model: args.cfg.generatorModel,
+    system,
+    user,
+  });
+
+  const parsed = JSON.parse(raw) as { relevance?: Record<string, string[]> };
+  const relevance = parsed.relevance;
+  if (!relevance || typeof relevance !== "object") {
+    throw new Error("Tool relevance LLM response missing 'relevance' key");
+  }
+
+  const allToolNames = new Set(args.tools.map((t) => t.name));
+  const result: Record<string, string[]> = {};
+  for (const doc of args.evaluatorDocs) {
+    const mapped = relevance[doc.id];
+    if (Array.isArray(mapped)) {
+      result[doc.id] = mapped.filter((name) => allToolNames.has(name));
+    } else {
+      result[doc.id] = [];
+    }
+  }
+
+  return result;
 }
 
 export async function generateAttackPlan(args: {
@@ -152,6 +229,7 @@ export async function generateAttackPlan(args: {
   tools: ToolInfo[];
   evaluatorDocs: EvaluatorDoc[];
   turns?: number;
+  toolFilter?: boolean;
 }): Promise<AttackPlanWritten> {
   const transport = args.cfg.server.transport;
   const serverSummary =
@@ -165,14 +243,46 @@ export async function generateAttackPlan(args: {
   // tool-description-scan is handled programmatically — skip it in the LLM loop
   const llmEvaluatorDocs = args.evaluatorDocs.filter((d) => d.id !== "tool-description-scan");
 
+  // Tool filtering: for MCPs with many tools, ask the LLM to score
+  // which tools are relevant for each evaluator before generating attacks.
+  const enableFilter = args.toolFilter !== false && args.tools.length > 5;
+  let relevanceMap: Record<string, string[]> | undefined;
+  if (enableFilter) {
+    log.start(
+      `Scoring tool relevance (${args.tools.length} tools × ${llmEvaluatorDocs.length} evaluators)…`
+    );
+    try {
+      relevanceMap = await computeToolRelevanceMap({
+        cfg: args.cfg,
+        tools: args.tools,
+        evaluatorDocs: llmEvaluatorDocs,
+      });
+      const pairs = Object.values(relevanceMap).reduce((sum, arr) => sum + arr.length, 0);
+      log.success(
+        `Tool filtering: ${pairs} relevant pairs (down from ${args.tools.length * llmEvaluatorDocs.length})`
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`Tool relevance scoring failed (${msg}), using all tools for every evaluator`);
+      relevanceMap = undefined;
+    }
+  }
+
   for (const evaluatorDoc of llmEvaluatorDocs) {
-    log.start(`Generating attacks for evaluator: ${evaluatorDoc.id} (${evaluatorDoc.name})…`);
+    let toolsForEval = args.tools;
+    if (relevanceMap && relevanceMap[evaluatorDoc.id]?.length > 0) {
+      const relevantNames = new Set(relevanceMap[evaluatorDoc.id]);
+      toolsForEval = args.tools.filter((t) => relevantNames.has(t.name));
+    }
+    log.start(
+      `Generating attacks for evaluator: ${evaluatorDoc.id} (${evaluatorDoc.name}) [${toolsForEval.length} tools]…`
+    );
     const attacks = await generateAttacksForEvaluator({
       cfg: args.cfg,
       suiteId: args.suiteId,
       transport,
       serverSummary,
-      tools: args.tools,
+      tools: toolsForEval,
       evaluatorDoc,
     });
     log.success(`  ${evaluatorDoc.id}: ${attacks.length} attacks`);
@@ -219,6 +329,7 @@ export async function generateAttackPlan(args: {
     generatorModel: args.cfg.generatorModel,
     judgeModel: args.cfg.judgeModel,
     attackerInstructions: args.cfg.attackerInstructions,
+    ...(relevanceMap ? { toolRelevanceMap: relevanceMap } : {}),
   };
 
   return plan;

--- a/core/src/attacks/planSchema.ts
+++ b/core/src/attacks/planSchema.ts
@@ -45,6 +45,8 @@ export const AttackPlanSchema = z.object({
   generatorModel: ModelConfigSchema.optional(),
   judgeModel: ModelConfigSchema.optional(),
   attackerInstructions: z.string().optional(),
+  /** Which tools were deemed relevant for each evaluator (written when tool filtering is active). */
+  toolRelevanceMap: z.record(z.string(), z.array(z.string())).optional(),
 });
 
 export type AttackPlan = z.infer<typeof AttackPlanSchema>;

--- a/core/src/config/schema.ts
+++ b/core/src/config/schema.ts
@@ -33,6 +33,10 @@ export const AstraMcpConfigSchema = z.object({
   server: McpServerConfigSchema,
   generatorModel: ModelConfigSchema,
   judgeModel: ModelConfigSchema.optional(),
+  /** Suite ID to use (default: "owasp-mcp-top10"). Ignored if evaluators[] is set. */
+  suite: z.string().min(1).optional(),
+  /** Explicit evaluator IDs. Takes priority over suite when both are set. */
+  evaluators: z.array(z.string().min(1)).optional(),
   /** "single" (default) fires one attack per scenario; "multi" runs adaptive multi-turn red-teaming. */
   turnMode: z.enum(["single", "multi"]).optional(),
   /** Number of adaptive turns per attack when turnMode is "multi" (default 3). */

--- a/core/src/llm/openaiCompatible.ts
+++ b/core/src/llm/openaiCompatible.ts
@@ -68,34 +68,41 @@ export async function chatCompletionJsonContent(args: {
   // Some providers (e.g. OpenRouter free models) silently ignore it or return an error,
   // so we fall back to plain text + manual JSON extraction.
   let useJsonMode = true;
+  let useTemperature = true;
 
-  const makeBody = (jsonMode: boolean) =>
+  const makeBody = (opts: { jsonMode: boolean; temperature: boolean }) =>
     JSON.stringify({
       model: args.model.model,
-      temperature: 0.2,
-      ...(jsonMode ? { response_format: { type: "json_object" } } : {}),
+      ...(opts.temperature ? { temperature: 1 } : {}),
+      ...(opts.jsonMode ? { response_format: { type: "json_object" } } : {}),
       messages: [
         { role: "system", content: args.system },
         { role: "user", content: args.user },
       ],
     });
 
-  const doFetch = (jsonMode: boolean) =>
+  const doFetch = () =>
     fetch(url, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
         "Content-Type": "application/json",
       },
-      body: makeBody(jsonMode),
+      body: makeBody({ jsonMode: useJsonMode, temperature: useTemperature }),
     });
 
-  let res = await doFetch(useJsonMode);
+  let res = await doFetch();
 
-  // 400 from OpenRouter/some hosts means json_object mode is unsupported — retry without it.
-  if (!res.ok && res.status === 400 && useJsonMode) {
-    useJsonMode = false;
-    res = await doFetch(false);
+  // 400 often means unsupported params — strip json_object and/or temperature and retry.
+  if (!res.ok && res.status === 400) {
+    if (useJsonMode) {
+      useJsonMode = false;
+      res = await doFetch();
+    }
+    if (!res.ok && res.status === 400 && useTemperature) {
+      useTemperature = false;
+      res = await doFetch();
+    }
   }
 
   // 429 rate limit — retry with exponential backoff (up to 3 attempts).
@@ -105,7 +112,7 @@ export async function chatCompletionJsonContent(args: {
       const retryAfterHeader = res.headers.get("retry-after");
       const waitMs = retryAfterHeader ? parseInt(retryAfterHeader) * 1000 : delay;
       await new Promise((r) => setTimeout(r, waitMs));
-      res = await doFetch(useJsonMode);
+      res = await doFetch();
       if (res.status !== 429) break;
     }
   }

--- a/core/src/run/judge.ts
+++ b/core/src/run/judge.ts
@@ -48,6 +48,23 @@ The TOOL RESPONSE IS the tool description text. FAIL only if it contains explici
 
 const DESCRIPTION_SCAN_ARGS_PREFIX = "_astra_scan";
 
+/**
+ * Cap tool responses to stay well within LLM context windows.
+ * Keeps the first and last portions so both early leakage and
+ * trailing error messages are visible to the judge.
+ */
+const MAX_RESPONSE_CHARS = 120_000; // ~30k tokens for most tokenizers
+
+function truncateResponse(text: string): string {
+  if (text.length <= MAX_RESPONSE_CHARS) return text;
+  const headSize = Math.floor(MAX_RESPONSE_CHARS * 0.7);
+  const tailSize = MAX_RESPONSE_CHARS - headSize;
+  const head = text.slice(0, headSize);
+  const tail = text.slice(-tailSize);
+  const dropped = text.length - headSize - tailSize;
+  return `${head}\n\n[… ${dropped.toLocaleString()} characters truncated …]\n\n${tail}`;
+}
+
 /** Build an ERROR JudgeResult for MCP transport failures (server crash, unknown tool, protocol error). */
 export function errorJudge(errorMessage: string): JudgeResult {
   return {
@@ -102,9 +119,9 @@ export async function judgeToolResponse(args: {
     })();
     responseBlock = `TOOL DESCRIPTION (static analysis — not a live response):\n${descriptionText}`;
   } else if (args.toolError) {
-    responseBlock = `TOOL ERROR: ${args.toolError}`;
+    responseBlock = `TOOL ERROR: ${truncateResponse(args.toolError)}`;
   } else {
-    responseBlock = `TOOL RESPONSE:\n${args.toolResponse || "(empty)"}`;
+    responseBlock = `TOOL RESPONSE:\n${truncateResponse(args.toolResponse || "(empty)")}`;
   }
 
   const user = [


### PR DESCRIPTION
- Added mcp tool filtering.
- This is needed as adversarial attack prompts need only be created for relevant tools, not all the tools.
- Also added option to select evaluators for mcp .
- Changed temperature for gptttt 5 to 1.0.
- Set agent response to 120k ( safe value for most agents. Eventually would need to introduce context summarisation)


