### PR TITLE
chore: prepare packages for npm registry publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/README.md
+++ b/README.md
@@ -216,3 +216,9 @@ Use opfor only on systems you own or are authorized to test. To report a vulnera
 ## License
 
 Opfor is licensed under Apache 2.0 — see the [LICENSE](LICENSE) file for details.
+
+---
+
+<p align="center">
+  Built with ❤️ by the <a href="https://keyvalue.systems">KeyValue</a> team, from India.
+</p>

--- a/README.md
+++ b/README.md
@@ -220,5 +220,5 @@ Opfor is licensed under Apache 2.0 — see the [LICENSE](LICENSE) file for detai
 ---
 
 <p align="center">
-  Built with ❤️ by the <a href="https://keyvalue.systems">KeyValue</a> team, from India.
+  Built with ❤️ by <a href="https://keyvalue.systems">KeyValue</a>
 </p>

--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,6 @@
   "version": "0.9.0",
   "description": "Opfor core engine — attacker prompt generation, judge, and execution shared by all runners",
   "license": "Apache-2.0",
-  "private": true,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -79,13 +78,18 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "evaluators",
+    "suites",
+    "skills"
   ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx/esm --test tests/*.test.ts"
+    "test": "node --import tsx/esm --test tests/*.test.ts",
+    "prepack": "cp -r ../evaluators ./evaluators && cp -r ../suites ./suites && cp -r ../skills ./skills",
+    "postpack": "rm -rf ./evaluators ./suites ./skills"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.77",

--- a/core/src/config/evaluatorsLayout.ts
+++ b/core/src/config/evaluatorsLayout.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +7,12 @@ const __dirname = path.dirname(realpathSync(fileURLToPath(import.meta.url)));
 export type EvaluatorCategory = "agent" | "mcp";
 
 export function getRepoRoot(): string {
+  // When installed from npm, data dirs are colocated at the package root (2 levels up from dist/config).
+  // In the monorepo, data dirs live at the repo root (3 levels up).
+  const packageRoot = path.resolve(__dirname, "../..");
+  if (existsSync(path.join(packageRoot, "evaluators"))) {
+    return packageRoot;
+  }
   return path.resolve(__dirname, "../../..");
 }
 

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -20,7 +20,7 @@
     "test": "node --import tsx/esm --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "*",
+    "@agent-opfor/core": "^0.9.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.165",
     "@anthropic-ai/sdk": "^0.100.1",
     "@ai-sdk/anthropic": "^2.0.77",

--- a/runners/cli/ui/package-lock.json
+++ b/runners/cli/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agent-opfor/autonomous-ui",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agent-opfor/autonomous-ui",
-      "version": "0.1.0",
+      "version": "0.9.0",
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0"

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agent-opfor/core": "*",
+    "@agent-opfor/core": "^0.9.0",
     "@ai-sdk/anthropic": "^2.0.77",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -22,7 +22,7 @@
     "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "*"
+    "@agent-opfor/core": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",


### PR DESCRIPTION
## Problem

The packages in this monorepo (`@agent-opfor/core`, `@agent-opfor/cli`, `@agent-opfor/mcp`, `@agent-opfor/sdk`) could not be published to an npm registry. Three blockers existed:

1. `@agent-opfor/core` was marked `"private": true` — the shared engine that all runners depend on.
2. The `evaluators/`, `suites/`, and `skills/` data directories were only referenced in the root `package.json` `files` field, but the root is `private`. After installing from npm, `getRepoRoot()` in `evaluatorsLayout.ts` resolved to the wrong path (3 levels up from `dist/config/` lands outside the package in `node_modules/@agent-opfor/`), so evaluator discovery would fail at runtime.
3. All runner packages declared `"@agent-opfor/core": "*"` — a wildcard resolved by npm workspaces locally but unresolvable from an external registry.

Additionally, the `release.yml` workflow was not passing `config-file` or `manifest-file` to the release-please action, so it was ignoring the monorepo config in `release-please-config.json`.

## Solution

- **Remove `private: true`** from `core/package.json`.
- **Add `prepack`/`postpack` scripts** to `core` that copy `evaluators/`, `suites/`, and `skills/` into the core package directory before packing and clean them up after. These dirs are also added to `core`'s `files` array.
- **Update `getRepoRoot()`** in `evaluatorsLayout.ts` to detect the runtime context: if `evaluators/` exists at the package root (2 levels up — published mode), use that path; otherwise fall back to 3 levels up (monorepo dev mode). This keeps local development working unchanged.
- **Pin `@agent-opfor/core`** from `"*"` to `"^0.9.0"` in `cli`, `mcp`, and `sdk` runners.
- **Wire `config-file` and `manifest-file`** in the release-please action so the monorepo config is respected.

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] `npm run build:catalog:check` passes _(if evaluators or suites changed)_
- [ ] Tested against a local target _(if evaluator added or changed)_
- [x] No secrets, `.env`, or `.opfor/` artifacts committed
- [x] PR title follows `<type>: <what changed>`

## Evaluator checklist _(skip if no evaluator added)_

N/A — no evaluators changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved packaging so the core package can be published and installed with the required runtime assets.
  * Release automation now uses the project’s release configuration files directly.

* **Bug Fixes**
  * Fixed directory resolution so the app can find bundled resources correctly in both development and installed package layouts.
  * Updated related packages to use a consistent compatible core version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->