### PR TITLE
chore: prepare packages for npm registry publishing

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,9 +16,9 @@ body:
       options:
         - CLI (`opfor run` / `opfor setup`)
         - CLI — Autonomous mode (`opfor hunt`)
-        - MCP Server (`@agent-opfor/mcp`)
+        - MCP Server (`@keyvaluesystems/agent-opfor-mcp`)
         - Browser Extension
-        - SDK (`@agent-opfor/sdk`)
+        - SDK (`@keyvaluesystems/agent-opfor-sdk`)
         - Evaluators / Suites
         - Judge (LLM-as-judge)
         - Report (HTML / JSON output)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - run: npm run build
 
       - name: Core tests
-        run: npm test --workspace=@agent-opfor/core
+        run: npm test --workspace=@keyvaluesystems/agent-opfor-core
 
       - name: SDK tests
-        run: npm test --workspace=@agent-opfor/sdk
+        run: npm test --workspace=@keyvaluesystems/agent-opfor-sdk

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,14 @@ cli/node_modules/
 .opfor
 tracedata.json
 
+# Vendored into core/ at pack time by its prepack script (see core/package.json).
+# Cleaned up by postpack; ignored here so an interrupted pack can't commit copies.
+core/evaluators/
+core/suites/
+core/skills/
+core/data/
+core/atlas-data/
+
 # Pre-refactor local trees / accidental rebuilds (canonical code is cli/, core/, mcp/)
 /src/
 src/agent/**/dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Opfor is an open-source red-teaming toolkit for AI agents and MCP servers. It ge
 | Browser extension | Click the toolbar icon on any chat UI                                                          | Non-developers — QA, PMs, security analysts  |
 | MCP server        | `opfor_setup`, `opfor_run` tools                                                               | MCP-compatible host (Cursor, Claude Desktop) |
 | Skills            | `/opfor-setup`, `/opfor-run` slash commands                                                    | AI coding agent reads markdown skill files   |
-| SDK               | `import { run, hunt } from "@agent-opfor/sdk"`                                                 | Developers embedding opfor in their own code |
+| SDK               | `import { run, hunt } from "@keyvaluesystems/agent-opfor-sdk"`                                 | Developers embedding opfor in their own code |
 
 ---
 
@@ -26,7 +26,7 @@ Opfor is an open-source red-teaming toolkit for AI agents and MCP servers. It ge
 
 ```
 opfor/
-├── core/                          # @agent-opfor/core — shared engine (npm workspace, compiled to core/dist/)
+├── core/                          # @keyvaluesystems/agent-opfor-core — shared engine (npm workspace, compiled to core/dist/)
 │   └── src/
 │       ├── autonomous/            # Autonomous red-teaming orchestration (orchestrator, prompts, tools, state, report, knowledge)
 │       ├── catalog/               # discoverEvaluators.ts, loadCatalog.ts — YAML evaluator/suite discovery
@@ -46,7 +46,7 @@ opfor/
 │       ├── prompts/               # Inlined system prompts (attacker, judge) used by core
 │       └── util/                  # yamlFrontmatter.ts and other utility helpers
 ├── runners/
-│   ├── cli/                       # @agent-opfor/cli — `opfor` CLI binary (npm workspace)
+│   ├── cli/                       # @keyvaluesystems/agent-opfor-cli — `opfor` CLI binary (npm workspace)
 │   │   └── src/
 │   │       ├── index.ts           # CLI entrypoint (commander) — registers setup, run, and hunt
 │   │       ├── commands/
@@ -55,18 +55,18 @@ opfor/
 │   │       │   └── hunt.ts        # `opfor hunt` — autonomous red-teaming with agentic orchestration
 │   │       └── lib/
 │   │           └── artifacts.ts   # .opfor/configs/ + .opfor/reports/ path helpers
-│   ├── mcp/                       # @agent-opfor/mcp — MCP server runner (npm workspace)
+│   ├── mcp/                       # @keyvaluesystems/agent-opfor-mcp — MCP server runner (npm workspace)
 │   │   └── src/
 │   │       └── index.ts           # MCP server entrypoint — registers tools, stdio transport
-│   ├── sdk/                       # @agent-opfor/sdk — programmatic SDK (npm workspace)
+│   ├── sdk/                       # @keyvaluesystems/agent-opfor-sdk — programmatic SDK (npm workspace)
 │   │   └── src/
 │   │       └── index.ts           # SDK entrypoint
-│   └── extension/                 # @agent-opfor/extension — Chrome MV3 browser extension (npm workspace)
+│   └── extension/                 # @keyvaluesystems/agent-opfor-extension — Chrome MV3 browser extension (npm workspace)
 │       ├── service_worker.js      # Entry point — message routing only; imports modules below
 │       ├── orchestrator.js        # Main run loop: locate → attack → extract → reset → judge (calls runAllBrowser from bundled core)
 │       ├── llmUiActions.js        # DOM-specific LLM helpers (input picker, UI planner, message shortener)
 │       ├── domTarget.js           # Adapter exposing the DOM send/extract path as a core AgentTarget
-│       ├── dist/core.bundle.js    # esbuild bundle of @agent-opfor/core/browser (attack + judge engine)
+│       ├── dist/core.bundle.js    # esbuild bundle of @keyvaluesystems/agent-opfor-core/browser (attack + judge engine)
 │       ├── frameDiscovery.js      # Frame collection, scoring, chat-frame selection
 │       ├── domActions.js          # chrome.scripting wrappers (send, click, verify, vendor APIs)
 │       ├── responseExtractor.js   # Three-phase polling extractor for bot responses
@@ -135,7 +135,7 @@ opfor/
 │   ├── mcp.md                     # MCP server (runner) setup + tools reference
 │   ├── browser-extension.md       # Browser extension guide
 │   ├── skills.md                  # Skill bundle usage
-│   ├── sdk.md                     # SDK (@agent-opfor/sdk) reference
+│   ├── sdk.md                     # SDK (@keyvaluesystems/agent-opfor-sdk) reference
 │   ├── evaluators.md              # Evaluator + suite reference
 │   ├── evaluator-schema.md        # Evaluator YAML schema
 │   └── telemetry.md               # Trace-aware testing (Langfuse / Netra)
@@ -158,7 +158,7 @@ npm run format:check              # prettier --check
 npm test                          # vitest in core/
 ```
 
-`core` must compile before any runner — `runners/{cli,mcp}` import from `core/dist/`, and `runners/extension` esbuild-bundles `@agent-opfor/core/browser` at build time. Always run `npm run build` from the repo root, never per-package.
+`core` must compile before any runner — `runners/{cli,mcp}` import from `core/dist/`, and `runners/extension` esbuild-bundles `@keyvaluesystems/agent-opfor-core/browser` at build time. Always run `npm run build` from the repo root, never per-package.
 
 ---
 
@@ -197,7 +197,7 @@ npm test                          # vitest in core/
 | `runners/extension/service_worker.js`    | Extension entry point — message routing; imports from focused ES modules                                                                                                    |
 | `runners/extension/orchestrator.js`      | Full adaptive run loop — drives `runAllBrowser` against `DomTarget`                                                                                                         |
 | `runners/extension/domTarget.js`         | Implements the core `AgentTarget` interface against the live chat DOM                                                                                                       |
-| `runners/extension/dist/core.bundle.js`  | esbuild bundle of `@agent-opfor/core/browser`; supplies `runAllBrowser` + `generateNextTurn` + judge                                                                        |
+| `runners/extension/dist/core.bundle.js`  | esbuild bundle of `@keyvaluesystems/agent-opfor-core/browser`; supplies `runAllBrowser` + `generateNextTurn` + judge                                                        |
 
 ---
 
@@ -342,7 +342,7 @@ For a new MCP _transport_ (beyond stdio/url):
 - **No barrel re-exports** — import directly from the file that owns the symbol
 - **Error messages are actionable** — tell the user what to fix, not just what went wrong
 - **Evaluator files are data** — no business logic in `.md` files; logic lives in `core/src/evaluators/`
-- **Never invoke the CLI as a subprocess from the MCP server** — call `@agent-opfor/core` directly
+- **Never invoke the CLI as a subprocess from the MCP server** — call `@keyvaluesystems/agent-opfor-core` directly
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Opfor is an open-source red-teaming toolkit for AI agents and MCP servers. It ge
 
 ## Monorepo structure
 
-```
+```text
 opfor/
 ├── core/                          # @keyvaluesystems/agent-opfor-core — shared engine (npm workspace, compiled to core/dist/)
 │   └── src/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -456,7 +456,7 @@ Only submit findings for systems you are authorized to test, or where you have c
 ### Project structure
 
 ```
-core/                       ← @agent-opfor/core — shared engine (npm workspace)
+core/                       ← @keyvaluesystems/agent-opfor-core — shared engine (npm workspace)
   src/
     autonomous/             ← autonomous red-teaming orchestration (opfor hunt)
     catalog/                ← evaluator/suite discovery + loading
@@ -473,9 +473,9 @@ core/                       ← @agent-opfor/core — shared engine (npm workspa
     targets/                ← agent + MCP target adapters
     telemetry/              ← Langfuse + Netra adapters
 runners/
-  cli/                      ← @agent-opfor/cli — `opfor setup`, `opfor run`, `opfor hunt`
-  mcp/                      ← @agent-opfor/mcp — opfor as an MCP server
-  sdk/                      ← @agent-opfor/sdk — programmatic SDK for embedding
+  cli/                      ← @keyvaluesystems/agent-opfor-cli — `opfor setup`, `opfor run`, `opfor hunt`
+  mcp/                      ← @keyvaluesystems/agent-opfor-mcp — opfor as an MCP server
+  sdk/                      ← @keyvaluesystems/agent-opfor-sdk — programmatic SDK for embedding
   extension/                ← Chrome MV3 browser extension
 evaluators/
   agent/                      ← agent evaluators by category

--- a/README.md
+++ b/README.md
@@ -220,5 +220,5 @@ Opfor is licensed under Apache 2.0 — see the [LICENSE](LICENSE) file for detai
 ---
 
 <p align="center">
-  Built with ❤️ by <a href="https://keyvalue.systems">KeyValue</a>
+  Built with ❤️ by the <a href="https://keyvalue.systems">KeyValue</a> team, from India.
 </p>

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Apache 2.0. Built from India.
 ## Quick Start
 
 ```bash
-npm install -g @agent-opfor/cli
+npm install -g @keyvaluesystems/agent-opfor-cli
 export OPENAI_API_KEY=your-key    # or GEMINI_API_KEY, ANTHROPIC_API_KEY, etc.
 ```
 
@@ -75,13 +75,13 @@ Most red-team tooling in this space is excellent at one thing — a probe librar
 
 Different people on your team need different entry points. Opfor ships five.
 
-| Mode                     | How                                                                     | Best for                                                                                  |
-| ------------------------ | ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
-| 🖥️ **CLI**               | `opfor setup` → `opfor run`                                             | Engineers, CI/CD, terminal-first workflows                                                |
-| 🌐 **Browser extension** | Install the extension, click the icon on any chat interface             | Product managers, designers, QA, security analysts — anyone who can't or won't write code |
-| 🤖 **MCP server**        | Register opfor in Cursor or Claude Desktop, then ask in chat            | AI coding agents that test your other agents                                              |
-| ⚡ **Skills**            | `/opfor-setup` · `/opfor-run` · `/opfor-mcp-setup` · `/opfor-mcp-run`   | Developers who want one-command testing inside their IDE                                  |
-| 📦 **SDK**               | `npm install @agent-opfor/sdk`, then call `run` / `hunt` from your code | Programmatic red-teaming and custom workflows                                             |
+| Mode                     | How                                                                                     | Best for                                                                                  |
+| ------------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| 🖥️ **CLI**               | `opfor setup` → `opfor run`                                                             | Engineers, CI/CD, terminal-first workflows                                                |
+| 🌐 **Browser extension** | Install the extension, click the icon on any chat interface                             | Product managers, designers, QA, security analysts — anyone who can't or won't write code |
+| 🤖 **MCP server**        | Register opfor in Cursor or Claude Desktop, then ask in chat                            | AI coding agents that test your other agents                                              |
+| ⚡ **Skills**            | `/opfor-setup` · `/opfor-run` · `/opfor-mcp-setup` · `/opfor-mcp-run`                   | Developers who want one-command testing inside their IDE                                  |
+| 📦 **SDK**               | `npm install @keyvaluesystems/agent-opfor-sdk`, then call `run` / `hunt` from your code | Programmatic red-teaming and custom workflows                                             |
 
 All five share the same evaluators, attack templates, and judge logic.
 
@@ -160,10 +160,10 @@ This is the path for the half of every product team that doesn't open a terminal
 
 ## SDK — embed red-teaming in your code
 
-The SDK is opfor's programmatic path. Install `@agent-opfor/sdk`, call `run` or `hunt`, and get structured results back — no CLI, no config files, no subprocess.
+The SDK is opfor's programmatic path. Install `@keyvaluesystems/agent-opfor-sdk`, call `run` or `hunt`, and get structured results back — no CLI, no config files, no subprocess.
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({ apiKey: process.env.ANTHROPIC_API_KEY });
 

--- a/README.md
+++ b/README.md
@@ -220,5 +220,5 @@ Opfor is licensed under Apache 2.0 — see the [LICENSE](LICENSE) file for detai
 ---
 
 <p align="center">
-  Built with ❤️ by the <a href="https://keyvalue.systems">KeyValue</a> team, from India.
+  Built with ❤️ by <a href="https://keyvalue.systems">KeyValue</a>
 </p>

--- a/core/package.json
+++ b/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/core",
+  "name": "@keyvaluesystems/agent-opfor-core",
   "version": "0.9.0",
   "description": "Opfor core engine — attacker prompt generation, judge, and execution shared by all runners",
   "license": "Apache-2.0",
@@ -81,15 +81,17 @@
     "src",
     "evaluators",
     "suites",
-    "skills"
+    "skills",
+    "atlas-data",
+    "data"
   ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --import tsx/esm --test tests/*.test.ts",
-    "prepack": "cp -r ../evaluators ./evaluators && cp -r ../suites ./suites && cp -r ../skills ./skills",
-    "postpack": "rm -rf ./evaluators ./suites ./skills"
+    "prepack": "cp -r ../evaluators ./evaluators && cp -r ../suites ./suites && cp -r ../skills ./skills && cp -r ../runners/cli/data ./data && mkdir -p ./atlas-data && cp ../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml",
+    "postpack": "rm -rf ./evaluators ./suites ./skills ./data ./atlas-data"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.77",

--- a/core/package.json
+++ b/core/package.json
@@ -3,7 +3,6 @@
   "version": "0.9.0",
   "description": "Opfor core engine — attacker prompt generation, judge, and execution shared by all runners",
   "license": "Apache-2.0",
-  "private": true,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -79,13 +78,18 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "evaluators",
+    "suites",
+    "skills"
   ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx/esm --test tests/*.test.ts"
+    "test": "node --import tsx/esm --test tests/*.test.ts",
+    "prepack": "cp -r ../evaluators ./evaluators && cp -r ../suites ./suites && cp -r ../skills ./skills",
+    "postpack": "rm -rf ./evaluators ./suites ./skills"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.77",

--- a/core/package.json
+++ b/core/package.json
@@ -3,6 +3,7 @@
   "version": "0.9.0",
   "description": "Opfor core engine — attacker prompt generation, judge, and execution shared by all runners",
   "license": "Apache-2.0",
+  "private": true,
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -78,20 +79,13 @@
   },
   "files": [
     "dist",
-    "src",
-    "evaluators",
-    "suites",
-    "skills",
-    "atlas-data",
-    "data"
+    "src"
   ],
   "sideEffects": false,
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx/esm --test tests/*.test.ts",
-    "prepack": "cp -r ../evaluators ./evaluators && cp -r ../suites ./suites && cp -r ../skills ./skills && cp -r ../runners/cli/data ./data && mkdir -p ./atlas-data && cp ../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml",
-    "postpack": "rm -rf ./evaluators ./suites ./skills ./data ./atlas-data"
+    "test": "node --import tsx/esm --test tests/*.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.77",

--- a/core/src/autonomous/index.ts
+++ b/core/src/autonomous/index.ts
@@ -1,8 +1,8 @@
 /**
  * Autonomous red-team engine — public API.
  *
- * Consumers import from "@agent-opfor/core/autonomous/index.js" (or sub-paths
- * like "@agent-opfor/core/autonomous/report/types.js" for deeper access).
+ * Consumers import from "@keyvaluesystems/agent-opfor-core/autonomous/index.js" (or sub-paths
+ * like "@keyvaluesystems/agent-opfor-core/autonomous/report/types.js" for deeper access).
  */
 
 export { runAutonomous } from "./orchestrator/run.js";

--- a/core/src/autonomous/knowledge/load.ts
+++ b/core/src/autonomous/knowledge/load.ts
@@ -2,6 +2,7 @@
 // Uses core's shared frontmatter parser. Resolves the bundled `data/`
 // directory relative to this module so it works regardless of the caller's cwd.
 
+import { existsSync } from "node:fs";
 import { readFile, readdir, writeFile, mkdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,13 +13,18 @@ import type { KnowledgeBase, VulnClass, Persona, Strategy, KnowledgeKind } from 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
- * Resolve the seed data directory. At runtime this module lives in
- * `core/dist/autonomous/knowledge/load.js`, so the bundled seeds are at
- * `../../../../runners/cli/data` (the CLI's `data/` dir shipped via
- * package.json `files`). Callers should always pass `seedDir`
- * explicitly; this fallback is a best-effort for in-repo dev use.
+ * Resolve the seed data directory. Two layouts are supported:
+ * - Published package: `<core>/data` (vendored into the tarball at pack time). This module
+ *   lives at `core/dist/autonomous/knowledge/load.js`, so the package root is 3 levels up.
+ * - Monorepo dev: `<repo>/runners/cli/data` (the source of truth, 4 levels up).
+ *
+ * Callers may still pass `seedDir` explicitly to override.
  */
 function defaultSeedDir(): string {
+  const packageLocal = path.resolve(__dirname, "../../../data");
+  if (existsSync(packageLocal)) {
+    return packageLocal;
+  }
   return path.resolve(__dirname, "../../../../runners/cli/data");
 }
 

--- a/core/src/autonomous/lib/types.ts
+++ b/core/src/autonomous/lib/types.ts
@@ -1,5 +1,5 @@
 // Shared option/config types for the autonomous red-team runner.
-// This package is fully standalone — it does NOT import from @agent-opfor/core.
+// This package is fully standalone — it does NOT import from @keyvaluesystems/agent-opfor-core.
 
 /** How the target HTTP agent maintains conversation state. */
 export type TargetMode = "stateless" | "stateful";

--- a/core/src/browser.ts
+++ b/core/src/browser.ts
@@ -1,4 +1,4 @@
-// Browser-safe entry for @agent-opfor/core. Re-exports only the parts of the engine
+// Browser-safe entry for @keyvaluesystems/agent-opfor-core. Re-exports only the parts of the engine
 // that are reachable from a Chrome MV3 extension or any other non-Node runtime.
 //
 // What's IN: attacker prompt generation, multi-turn escalation, judge logic,

--- a/core/src/catalog/loadEvaluatorCatalog.ts
+++ b/core/src/catalog/loadEvaluatorCatalog.ts
@@ -4,6 +4,7 @@ import { type EvaluatorCategory } from "../config/evaluatorsLayout.js";
 import { discoverEvaluatorFiles, discoverSuiteFiles } from "./discoverEvaluators.js";
 import { resolveStandardsFromFrontmatter } from "../evaluators/standards.js";
 import { loadAtlasTechniqueIdSet } from "../standards/atlas.js";
+import { log } from "../lib/logger.js";
 import type { StandardsMap } from "../evaluators/schema.js";
 
 export interface EvaluatorMeta {
@@ -111,7 +112,18 @@ export async function loadEvaluatorCatalog(category: EvaluatorCategory): Promise
   suites: SuiteMeta[];
 }> {
   const validateAtlas = process.env.OPFOR_VALIDATE_ATLAS !== "0"; // On by default now
-  const atlasTechniqueIds = validateAtlas ? await loadAtlasTechniqueIdSet() : null;
+  let atlasTechniqueIds: Set<string> | null = null;
+  if (validateAtlas) {
+    try {
+      atlasTechniqueIds = await loadAtlasTechniqueIdSet();
+    } catch (e: unknown) {
+      // ATLAS data is an authoring-time validation aid. If it's unavailable at runtime
+      // (e.g. a published install where the data wasn't bundled), skip validation rather
+      // than crash a scan. Set OPFOR_VALIDATE_ATLAS=0 to silence this.
+      const msg = e instanceof Error ? e.message : String(e);
+      log.warn(`Skipping ATLAS technique-id validation: ${msg.split("\n")[0]}`);
+    }
+  }
 
   // Discover and load evaluators
   const discoveredEvaluators = await discoverEvaluatorFiles(category);

--- a/core/src/config/evaluatorsLayout.ts
+++ b/core/src/config/evaluatorsLayout.ts
@@ -8,11 +8,13 @@ export type EvaluatorCategory = "agent" | "mcp";
 
 export function getRepoRoot(): string {
   // Bundled runner: data dirs at package root, one level up from dist/
+  // Check for evaluators/agent/ (not just evaluators/) to avoid false-matching
+  // core/src/evaluators/ which is a TypeScript source directory, not data.
   const oneUp = path.resolve(__dirname, "..");
-  if (existsSync(path.join(oneUp, "evaluators"))) return oneUp;
+  if (existsSync(path.join(oneUp, "evaluators", "agent"))) return oneUp;
   // Compiled core (npm installed): data dirs colocated at core package root, 2 levels up from dist/config/
   const twoUp = path.resolve(__dirname, "../..");
-  if (existsSync(path.join(twoUp, "evaluators"))) return twoUp;
+  if (existsSync(path.join(twoUp, "evaluators", "agent"))) return twoUp;
   // Monorepo: data dirs at repo root, 3 levels up from core/dist/config/
   return path.resolve(__dirname, "../../..");
 }

--- a/core/src/config/evaluatorsLayout.ts
+++ b/core/src/config/evaluatorsLayout.ts
@@ -7,12 +7,13 @@ const __dirname = path.dirname(realpathSync(fileURLToPath(import.meta.url)));
 export type EvaluatorCategory = "agent" | "mcp";
 
 export function getRepoRoot(): string {
-  // When installed from npm, data dirs are colocated at the package root (2 levels up from dist/config).
-  // In the monorepo, data dirs live at the repo root (3 levels up).
-  const packageRoot = path.resolve(__dirname, "../..");
-  if (existsSync(path.join(packageRoot, "evaluators"))) {
-    return packageRoot;
-  }
+  // Bundled runner: data dirs at package root, one level up from dist/
+  const oneUp = path.resolve(__dirname, "..");
+  if (existsSync(path.join(oneUp, "evaluators"))) return oneUp;
+  // Compiled core (npm installed): data dirs colocated at core package root, 2 levels up from dist/config/
+  const twoUp = path.resolve(__dirname, "../..");
+  if (existsSync(path.join(twoUp, "evaluators"))) return twoUp;
+  // Monorepo: data dirs at repo root, 3 levels up from core/dist/config/
   return path.resolve(__dirname, "../../..");
 }
 

--- a/core/src/config/evaluatorsLayout.ts
+++ b/core/src/config/evaluatorsLayout.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +7,12 @@ const __dirname = path.dirname(realpathSync(fileURLToPath(import.meta.url)));
 export type EvaluatorCategory = "agent" | "mcp";
 
 export function getRepoRoot(): string {
+  // When installed from npm, data dirs are colocated at the package root (2 levels up from dist/config).
+  // In the monorepo, data dirs live at the repo root (3 levels up).
+  const packageRoot = path.resolve(__dirname, "../..");
+  if (existsSync(path.join(packageRoot, "evaluators"))) {
+    return packageRoot;
+  }
   return path.resolve(__dirname, "../../..");
 }
 

--- a/core/src/report/types.ts
+++ b/core/src/report/types.ts
@@ -5,7 +5,7 @@
 
 import type { JudgeResult } from "../lib/judgeTypes.js";
 
-/** @deprecated Use JudgeResult from @agent-opfor/core/lib/judgeTypes.js directly. */
+/** @deprecated Use JudgeResult from @keyvaluesystems/agent-opfor-core/lib/judgeTypes.js directly. */
 export type ReportJudge = JudgeResult;
 
 export type DetailCard =

--- a/core/src/standards/atlas.ts
+++ b/core/src/standards/atlas.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -23,21 +24,28 @@ interface AtlasYamlDoc {
   matrices?: AtlasYamlMatrix[];
 }
 
-function repoRootFromHere(): string {
-  const here = path.dirname(fileURLToPath(import.meta.url));
-  // core/src/standards -> repo root
-  return path.resolve(here, "..", "..", "..");
-}
-
+/**
+ * Resolve the ATLAS YAML. Two layouts are supported:
+ * - Published package: `<core>/atlas-data/ATLAS.yaml` (vendored into the tarball at pack time).
+ * - Monorepo dev: `<repo>/third_party/atlas-data/dist/ATLAS.yaml` (the git submodule).
+ *
+ * This module is at `core/{src,dist}/standards/atlas.{ts,js}`, so the package root is 2 levels
+ * up and the repo root is 3 levels up — true whether run from `src` (tsx) or `dist` (compiled).
+ */
 function atlasYamlPath(): string {
-  return path.join(repoRootFromHere(), "third_party", "atlas-data", "dist", "ATLAS.yaml");
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const packageLocal = path.resolve(here, "..", "..", "atlas-data", "ATLAS.yaml");
+  if (existsSync(packageLocal)) {
+    return packageLocal;
+  }
+  return path.resolve(here, "..", "..", "..", "third_party", "atlas-data", "dist", "ATLAS.yaml");
 }
 
 function missingSubmoduleHelp(atlasPath: string): string {
   return [
-    `MITRE ATLAS submodule not found at ${atlasPath}.`,
+    `MITRE ATLAS data not found at ${atlasPath}.`,
     "",
-    "Initialize submodules with:",
+    "In a monorepo checkout, initialize submodules with:",
     "  git submodule update --init --recursive",
   ].join("\n");
 }

--- a/docs/browser-extension.md
+++ b/docs/browser-extension.md
@@ -37,7 +37,7 @@ For contributors or testing unreleased changes:
 git clone https://github.com/KeyValueSoftwareSystems/agent-opfor.git
 cd opfor
 npm install
-npm run build:catalog --workspace=@agent-opfor/extension
+npm run build:catalog --workspace=@keyvaluesystems/agent-opfor-extension
 ```
 
 Then `chrome://extensions` → enable **Developer mode** → **Load unpacked** → select the `runners/extension/` folder.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,7 +22,7 @@ Use agent mode for chatbots, RAG apps, and tool-calling agents fronted by an HTT
 ## Install
 
 ```bash
-npm install -g @agent-opfor/cli
+npm install -g @keyvaluesystems/agent-opfor-cli
 ```
 
 **From source (contributors):**

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -198,7 +198,7 @@ Once published, users can run the MCP server without cloning the repo:
   "mcpServers": {
     "opfor": {
       "command": "npx",
-      "args": ["-y", "@agent-opfor/mcp"]
+      "args": ["-y", "@keyvaluesystems/agent-opfor-mcp"]
     }
   }
 }

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -5,7 +5,7 @@ Adversarial testing for AI systems. TypeScript-first.
 ## Install
 
 ```bash
-npm install @agent-opfor/sdk
+npm install @keyvaluesystems/agent-opfor-sdk
 ```
 
 ## Quick Start
@@ -13,7 +13,7 @@ npm install @agent-opfor/sdk
 ### Class-based API
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -37,7 +37,7 @@ console.log(results.findings.length);
 For those who prefer functions over classes:
 
 ```typescript
-import { run, report } from "@agent-opfor/sdk";
+import { run, report } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await run({
   target: {
@@ -113,7 +113,7 @@ const results = await opfor.run({
 Let Opfor discover attack paths automatically using an AI agent. Unlike `run()` which runs predefined evaluators, `hunt()` uses adaptive multi-turn attacks to autonomously discover vulnerabilities.
 
 ```typescript
-import { hunt } from "@agent-opfor/sdk";
+import { hunt } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await hunt({
   target: {
@@ -279,7 +279,7 @@ const results = await opfor.run({
 Configure attacker and judge LLMs.
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({
   // Default API key (used if not specified per-model)
@@ -501,7 +501,7 @@ await r.json("./report.json");
 await r.html("./report.html");
 
 // Functional
-import { run, report } from "@agent-opfor/sdk";
+import { run, report } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await run({ ... });
 await report(results).json("./report.json");
@@ -568,7 +568,7 @@ await report(results).html("./report.html");
 ### Using Functional API
 
 ```typescript
-import { run } from "@agent-opfor/sdk";
+import { run } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await run({
   target: {
@@ -595,7 +595,7 @@ console.log(`Safety score: ${results.score}%`);
 ### Using Class API
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({
   apiKey: process.env.ANTHROPIC_API_KEY,
@@ -619,7 +619,7 @@ if (results.findings.length > 0) {
 ### Class-based
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({ apiKey: "..." });
 await opfor.run({ ... });
@@ -635,7 +635,7 @@ import {
   report, // Generate reports from results
   listSuites, // List available suites
   listEvaluators, // List available evaluators
-} from "@agent-opfor/sdk";
+} from "@keyvaluesystems/agent-opfor-sdk";
 
 // Execute with inline config
 const results = await run({
@@ -686,7 +686,7 @@ import type {
   AutoModelsConfig,
   AutoLimitsConfig,
   AutoProgressEvent,
-} from "@agent-opfor/sdk";
+} from "@keyvaluesystems/agent-opfor-sdk";
 ```
 
 ## Autonomous Mode Reference
@@ -792,7 +792,7 @@ type AutoProgressEvent =
 ### Example with Progress Streaming
 
 ```typescript
-import { hunt } from "@agent-opfor/sdk";
+import { hunt } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await hunt({
   target: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-opfor",
-  "version": "0.1.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-opfor",
-      "version": "0.1.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "workspaces": [
         "core",
@@ -35,8 +35,8 @@
       }
     },
     "core": {
-      "name": "@agent-opfor/core",
-      "version": "0.1.0",
+      "name": "@keyvaluesystems/agent-opfor-core",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.77",
@@ -69,26 +69,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@agent-opfor/cli": {
-      "resolved": "runners/cli",
-      "link": true
-    },
-    "node_modules/@agent-opfor/core": {
-      "resolved": "core",
-      "link": true
-    },
-    "node_modules/@agent-opfor/extension": {
-      "resolved": "runners/extension",
-      "link": true
-    },
-    "node_modules/@agent-opfor/mcp": {
-      "resolved": "runners/mcp",
-      "link": true
-    },
-    "node_modules/@agent-opfor/sdk": {
-      "resolved": "runners/sdk",
-      "link": true
     },
     "node_modules/@ai-sdk/anthropic": {
       "version": "2.0.79",
@@ -1718,6 +1698,26 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@keyvaluesystems/agent-opfor-cli": {
+      "resolved": "runners/cli",
+      "link": true
+    },
+    "node_modules/@keyvaluesystems/agent-opfor-core": {
+      "resolved": "core",
+      "link": true
+    },
+    "node_modules/@keyvaluesystems/agent-opfor-extension": {
+      "resolved": "runners/extension",
+      "link": true
+    },
+    "node_modules/@keyvaluesystems/agent-opfor-mcp": {
+      "resolved": "runners/mcp",
+      "link": true
+    },
+    "node_modules/@keyvaluesystems/agent-opfor-sdk": {
+      "resolved": "runners/sdk",
+      "link": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -4914,11 +4914,10 @@
       }
     },
     "runners/cli": {
-      "name": "@agent-opfor/cli",
-      "version": "0.1.0",
+      "name": "@keyvaluesystems/agent-opfor-cli",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-opfor/core": "*",
         "@ai-sdk/anthropic": "^2.0.77",
         "@ai-sdk/azure": "^3.0.65",
         "@ai-sdk/deepseek": "^2.0.35",
@@ -4928,6 +4927,7 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.165",
         "@anthropic-ai/sdk": "^0.100.1",
         "@inquirer/prompts": "^8.4.2",
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
         "commander": "^14.0.1",
@@ -4948,8 +4948,8 @@
       }
     },
     "runners/extension": {
-      "name": "@agent-opfor/extension",
-      "version": "0.0.1",
+      "name": "@keyvaluesystems/agent-opfor-extension",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "yaml": "^2.8.3"
@@ -5443,15 +5443,15 @@
       }
     },
     "runners/mcp": {
-      "name": "@agent-opfor/mcp",
-      "version": "0.1.0",
+      "name": "@keyvaluesystems/agent-opfor-mcp",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-opfor/core": "*",
         "@ai-sdk/anthropic": "^2.0.77",
         "@ai-sdk/google": "^2.0.70",
         "@ai-sdk/openai": "^2.0.103",
         "@ai-sdk/openai-compatible": "^1.0.0",
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
         "consola": "^3.4.2",
@@ -5469,11 +5469,11 @@
       }
     },
     "runners/sdk": {
-      "name": "@agent-opfor/sdk",
-      "version": "0.1.0",
+      "name": "@keyvaluesystems/agent-opfor-sdk",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@agent-opfor/core": "*"
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,6 +1699,45 @@
         }
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@keyvaluesystems/agent-opfor-cli": {
       "resolved": "runners/cli",
       "link": true
@@ -1763,6 +1802,356 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@simple-libs/child-process-utils": {
       "version": "1.0.2",
@@ -2305,6 +2694,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2364,11 +2760,37 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -2409,6 +2831,22 @@
     "node_modules/chardet": {
       "version": "2.1.1",
       "license": "MIT"
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -2507,6 +2945,13 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
       }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/consola": {
       "version": "3.4.2",
@@ -3286,6 +3731,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -3711,6 +4168,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3811,6 +4278,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -3858,6 +4338,16 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/locate-path": {
@@ -3911,6 +4401,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4000,6 +4500,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -4009,6 +4522,18 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/natural-compare": {
@@ -4189,6 +4714,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4209,11 +4741,76 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/prelude-ls": {
@@ -4298,6 +4895,20 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
@@ -4346,6 +4957,51 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -4531,6 +5187,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
@@ -4591,6 +5257,62 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
@@ -4625,6 +5347,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
@@ -4643,6 +5375,73 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tsup/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -4722,6 +5521,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -4927,7 +5733,6 @@
         "@anthropic-ai/claude-agent-sdk": "^0.3.165",
         "@anthropic-ai/sdk": "^0.100.1",
         "@inquirer/prompts": "^8.4.2",
-        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
         "commander": "^14.0.1",
@@ -4941,10 +5746,496 @@
         "opfor": "dist/index.js"
       },
       "devDependencies": {
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@types/express": "^5.0.3",
         "@types/node": "^24.0.0",
+        "esbuild": "^0.25.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/cli/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "runners/extension": {
@@ -5451,7 +6742,6 @@
         "@ai-sdk/google": "^2.0.70",
         "@ai-sdk/openai": "^2.0.103",
         "@ai-sdk/openai-compatible": "^1.0.0",
-        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
         "consola": "^3.4.2",
@@ -5463,20 +6753,505 @@
         "opfor-agent-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@types/node": "^24.0.0",
+        "esbuild": "^0.25.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "runners/mcp/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "runners/sdk": {
       "name": "@keyvaluesystems/agent-opfor-sdk",
       "version": "0.9.0",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@keyvaluesystems/agent-opfor-core": "^0.9.0"
-      },
       "devDependencies": {
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@types/node": "^24.0.0",
+        "tsup": "^8.0.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
       },

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "npm run build:catalog && tsc -b core runners/cli runners/mcp runners/sdk && npm run build:ui && npm run extension:catalog && npm run build:core --workspace=@agent-opfor/extension",
+    "build": "npm run build:catalog && tsc -b core runners/cli runners/mcp runners/sdk && npm run build:ui && npm run extension:catalog && npm run build:core --workspace=@keyvaluesystems/agent-opfor-extension",
     "build:ui": "cd runners/cli/ui && npm install && npm run build",
     "clean": "rm -rf core/dist runners/*/dist core/*.tsbuildinfo runners/*/*.tsbuildinfo",
     "install:cli": "npm run build && npm install -g ./runners/cli",
     "test": "npm test --workspace=core",
     "typecheck": "tsc -b core runners/cli runners/mcp runners/sdk",
-    "extension:catalog": "npm run build:catalog --workspace=@agent-opfor/extension",
+    "extension:catalog": "npm run build:catalog --workspace=@keyvaluesystems/agent-opfor-extension",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
@@ -37,6 +37,7 @@
     "validate:skills": "tsx scripts/validate-skills.ts",
     "build:catalog": "tsx scripts/build-catalog.ts",
     "build:catalog:check": "tsx scripts/build-catalog.ts --check",
+    "smoke:pack": "tsx scripts/smoke-pack.ts",
     "new:evaluator": "tsx scripts/new-evaluator.ts",
     "coverage:atlas": "tsx scripts/generate-atlas-coverage.ts",
     "report:pdf": "tsx scripts/generate-pdf-report.ts",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "npm run build:catalog && tsc -b core runners/cli runners/mcp runners/sdk && npm run build:ui && npm run extension:catalog && npm run build:core --workspace=@keyvaluesystems/agent-opfor-extension",
+    "build": "npm run build:catalog && tsc -b core && npm run build -w runners/cli && npm run build -w runners/mcp && npm run build -w runners/sdk && npm run extension:catalog && npm run build:core --workspace=@keyvaluesystems/agent-opfor-extension",
     "build:ui": "cd runners/cli/ui && npm install && npm run build",
     "clean": "rm -rf core/dist runners/*/dist core/*.tsbuildinfo runners/*/*.tsbuildinfo",
     "install:cli": "npm run build && npm install -g ./runners/cli",
     "test": "npm test --workspace=core",
-    "typecheck": "tsc -b core runners/cli runners/mcp runners/sdk",
+    "typecheck": "tsc -b core && npm run typecheck -w runners/cli && npm run typecheck -w runners/mcp && npm run typecheck -w runners/sdk",
     "extension:catalog": "npm run build:catalog --workspace=@keyvaluesystems/agent-opfor-extension",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/runners/cli/README.md
+++ b/runners/cli/README.md
@@ -1,0 +1,38 @@
+# @keyvaluesystems/agent-opfor-cli
+
+Opfor CLI — adversarial security testing for AI agents and MCP servers.
+
+## Installation
+
+```bash
+npm install -g @keyvaluesystems/agent-opfor-cli
+```
+
+## Quick Start
+
+```bash
+# Interactive setup wizard — generates a config file
+opfor setup
+
+# Run a red-team evaluation against a configured target
+opfor run --config .opfor/configs/opfor-config-<id>.json
+
+# Autonomous red-teaming (no config needed)
+opfor hunt --endpoint https://api.example.com/chat --objective "Extract system prompt"
+```
+
+## Commands
+
+| Command                                          | Description                                                |
+| ------------------------------------------------ | ---------------------------------------------------------- |
+| `opfor setup`                                    | Interactive wizard — configure target, evaluators, and LLM |
+| `opfor run --config <path>`                      | Run a full evaluation from a config file                   |
+| `opfor hunt --endpoint <url> --objective <text>` | Autonomous agentic red-team                                |
+
+## Documentation
+
+See [docs.agentopfor.ai/cli](https://docs.agentopfor.ai/cli) for full CLI reference and [docs.agentopfor.ai/hunt](https://docs.agentopfor.ai/hunt) for autonomous mode.
+
+## License
+
+Apache-2.0

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -9,18 +9,25 @@
   },
   "files": [
     "dist/",
-    "data/"
+    "data/",
+    "evaluators/",
+    "suites/",
+    "atlas-data/"
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "npm run build:ui && tsc -p tsconfig.json",
+    "build": "rm -rf dist && npm run build:ui && node scripts/bundle.mjs",
     "build:ui": "cd ui && npm install && npm run build",
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "node --import tsx/esm --test tests/*.test.ts"
+    "test": "node --import tsx/esm --test tests/*.test.ts",
+    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "postpack": "rm -rf ./evaluators ./suites ./atlas-data ./LICENSE"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
-    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.165",
     "@anthropic-ai/sdk": "^0.100.1",
     "@ai-sdk/anthropic": "^2.0.77",
@@ -40,8 +47,10 @@
     "zod": "^3.0.0"
   },
   "devDependencies": {
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@types/express": "^5.0.3",
     "@types/node": "^24.0.0",
+    "esbuild": "^0.25.0",
     "tsx": "^4.20.0",
     "typescript": "^5.8.3"
   }

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -21,7 +21,7 @@
     "start": "node dist/index.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --import tsx/esm --test tests/*.test.ts",
-    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "prepack": "rm -rf ./evaluators ./suites ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./atlas-data ./LICENSE"
   },
   "publishConfig": {

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/cli",
+  "name": "@keyvaluesystems/agent-opfor-cli",
   "version": "0.9.0",
   "description": "Opfor CLI — security testing for AI agents and MCP servers (opfor setup|run|hunt)",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     "test": "node --import tsx/esm --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "^0.9.0",
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.165",
     "@anthropic-ai/sdk": "^0.100.1",
     "@ai-sdk/anthropic": "^2.0.77",

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -20,7 +20,7 @@
     "test": "node --import tsx/esm --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "*",
+    "@agent-opfor/core": "^0.9.0",
     "@anthropic-ai/claude-agent-sdk": "^0.3.165",
     "@anthropic-ai/sdk": "^0.100.1",
     "@ai-sdk/anthropic": "^2.0.77",

--- a/runners/cli/scripts/bundle.mjs
+++ b/runners/cli/scripts/bundle.mjs
@@ -1,0 +1,25 @@
+import { build } from "esbuild";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [resolve(__dirname, "../src/index.ts")],
+  outfile: resolve(__dirname, "../dist/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "node20",
+  external: ["node:*"],
+  sourcemap: true,
+  // Shebang + createRequire shim: CJS packages (e.g. dotenv) use require('fs') which
+  // fails in ESM bundles without a real require available at runtime.
+  banner: {
+    js: [
+      "#!/usr/bin/env node",
+      "import { createRequire } from 'module';",
+      "const require = createRequire(import.meta.url);",
+    ].join("\n"),
+  },
+});

--- a/runners/cli/src/commands/hunt.ts
+++ b/runners/cli/src/commands/hunt.ts
@@ -7,10 +7,10 @@ import type {
   HuntOptions,
   TargetConfig,
   TargetMode,
-} from "@agent-opfor/core/autonomous/lib/types.js";
-import type { RunEvent } from "@agent-opfor/core/autonomous/state/observe.js";
-import { runAutonomous } from "@agent-opfor/core/autonomous/orchestrator/run.js";
-import { writeAutonomousReport } from "@agent-opfor/core/autonomous/report/writeReport.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
+import type { RunEvent } from "@keyvaluesystems/agent-opfor-core/autonomous/state/observe.js";
+import { runAutonomous } from "@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/run.js";
+import { writeAutonomousReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js";
 import { startUiServer } from "../ui/server.js";
 import { mergeReporters } from "../ui/bridge.js";
 

--- a/runners/cli/src/commands/run.ts
+++ b/runners/cli/src/commands/run.ts
@@ -1,12 +1,12 @@
 import type { Command } from "commander";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
-import { log } from "@agent-opfor/core/lib/logger.js";
-import { runAll } from "@agent-opfor/core/execute/runAll.js";
-import { writeReport } from "@agent-opfor/core/report/buildReport.js";
-import type { RunConfig } from "@agent-opfor/core/execute/types.js";
-import { parseRunConfig } from "@agent-opfor/core/config/schema.js";
-import { normalizeEffort } from "@agent-opfor/core/execute/effortCompat.js";
+import { log } from "@keyvaluesystems/agent-opfor-core/lib/logger.js";
+import { runAll } from "@keyvaluesystems/agent-opfor-core/execute/runAll.js";
+import { writeReport } from "@keyvaluesystems/agent-opfor-core/report/buildReport.js";
+import type { RunConfig } from "@keyvaluesystems/agent-opfor-core/execute/types.js";
+import { parseRunConfig } from "@keyvaluesystems/agent-opfor-core/config/schema.js";
+import { normalizeEffort } from "@keyvaluesystems/agent-opfor-core/execute/effortCompat.js";
 import { runSetupAndWrite } from "./setup.js";
 import { ensureOpforDirs, OPFOR_DIR, OPFOR_REPORTS_DIR } from "../lib/artifacts.js";
 

--- a/runners/cli/src/commands/setup.ts
+++ b/runners/cli/src/commands/setup.ts
@@ -2,8 +2,8 @@ import type { Command } from "commander";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { input, select, checkbox, confirm } from "@inquirer/prompts";
-import { log } from "@agent-opfor/core/lib/logger.js";
-import { loadSkillCatalog } from "@agent-opfor/core/config/loadSkillCatalog.js";
+import { log } from "@keyvaluesystems/agent-opfor-core/lib/logger.js";
+import { loadSkillCatalog } from "@keyvaluesystems/agent-opfor-core/config/loadSkillCatalog.js";
 import {
   PROVIDERS,
   PROVIDER_CHOICES,
@@ -12,8 +12,11 @@ import {
   type TelemetryConfig,
   type NetraTelemetryConfig,
   type LangfuseTelemetryConfig,
-} from "@agent-opfor/core/config/types.js";
-import { PROVIDER_DEFAULTS, PROVIDER_ENV_VARS } from "@agent-opfor/core/providers/factory.js";
+} from "@keyvaluesystems/agent-opfor-core/config/types.js";
+import {
+  PROVIDER_DEFAULTS,
+  PROVIDER_ENV_VARS,
+} from "@keyvaluesystems/agent-opfor-core/providers/factory.js";
 import type {
   RunConfig,
   UnifiedTargetConfig,
@@ -21,7 +24,7 @@ import type {
   McpTargetConfig,
   EvaluatorSelection,
   Effort,
-} from "@agent-opfor/core/execute/types.js";
+} from "@keyvaluesystems/agent-opfor-core/execute/types.js";
 import { ensureOpforDirs, newConfigPath } from "../lib/artifacts.js";
 
 /**

--- a/runners/cli/src/index.ts
+++ b/runners/cli/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Suppress Vercel AI SDK v1/v2 spec compatibility warnings — these fire for
 // custom/openai-compatible providers and are not actionable by the user.
 (globalThis as Record<string, unknown>).AI_SDK_LOG_WARNINGS = false;

--- a/runners/cli/src/ui/bridge.ts
+++ b/runners/cli/src/ui/bridge.ts
@@ -1,8 +1,8 @@
 // Bridges ProgressReporter callbacks to SSE clients and maintains run state for REST snapshots.
 
-import type { ProgressReporter } from "@agent-opfor/core/autonomous/state/hooks.js";
-import type { RunEvent } from "@agent-opfor/core/autonomous/state/observe.js";
-import type { RunLog } from "@agent-opfor/core/autonomous/state/runLog.js";
+import type { ProgressReporter } from "@keyvaluesystems/agent-opfor-core/autonomous/state/hooks.js";
+import type { RunEvent } from "@keyvaluesystems/agent-opfor-core/autonomous/state/observe.js";
+import type { RunLog } from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 import { serializeRunLog, type SnapshotMeta, type UiRunState } from "./snapshot.js";
 
 export type SsePayload =

--- a/runners/cli/src/ui/demoData.ts
+++ b/runners/cli/src/ui/demoData.ts
@@ -1,7 +1,7 @@
 // Scripted scenario for the live UI demo — no API calls, no budget spend.
 
 import type { UiRunState, UiThread } from "./snapshot.js";
-import type { Finding } from "@agent-opfor/core/autonomous/state/runLog.js";
+import type { Finding } from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 
 export const DEMO_META = {
   objective:

--- a/runners/cli/src/ui/server.ts
+++ b/runners/cli/src/ui/server.ts
@@ -8,13 +8,13 @@ import { createWriteStream, type WriteStream } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { exec } from "node:child_process";
 import express from "express";
-import type { RunLog } from "@agent-opfor/core/autonomous/state/runLog.js";
+import type { RunLog } from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 import type {
   HuntOptions,
   TargetConfig,
   TargetMode,
-} from "@agent-opfor/core/autonomous/lib/types.js";
-import type { RunEvent } from "@agent-opfor/core/autonomous/state/observe.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
+import type { RunEvent } from "@keyvaluesystems/agent-opfor-core/autonomous/state/observe.js";
 import { UiBridge, type SseClient } from "./bridge.js";
 import type { SnapshotMeta } from "./snapshot.js";
 
@@ -295,9 +295,10 @@ async function runAssessmentInProcess(
   bridge: UiBridge,
   onLog?: (line: string) => void
 ): Promise<string | undefined> {
-  const { runAutonomous } = await import("@agent-opfor/core/autonomous/orchestrator/run.js");
+  const { runAutonomous } =
+    await import("@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/run.js");
   const { writeAutonomousReport } =
-    await import("@agent-opfor/core/autonomous/report/writeReport.js");
+    await import("@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js");
 
   // Set up output directory and log files
   await mkdir(autoOptions.outputDir, { recursive: true });

--- a/runners/cli/src/ui/snapshot.ts
+++ b/runners/cli/src/ui/snapshot.ts
@@ -1,6 +1,9 @@
 // Serialize RunLog into a JSON-safe shape for the live UI REST API.
 
-import type { RunLog, ThreadState } from "@agent-opfor/core/autonomous/state/runLog.js";
+import type {
+  RunLog,
+  ThreadState,
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 
 export interface UiThreadTurn {
   turnIndex: number;

--- a/runners/cli/tests/fork.test.ts
+++ b/runners/cli/tests/fork.test.ts
@@ -7,9 +7,9 @@ import {
   sharesForkAncestry,
   evidenceFoundInThread,
   type Finding,
-} from "@agent-opfor/core/autonomous/state/runLog.js";
-import { BudgetGuard } from "@agent-opfor/core/autonomous/lib/budget.js";
-import { mapRunLogToReport } from "@agent-opfor/core/autonomous/report/mapRunLog.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
+import { BudgetGuard } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/budget.js";
+import { mapRunLogToReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/mapRunLog.js";
 
 function baseLog() {
   return createRunLog({

--- a/runners/cli/tests/http.test.ts
+++ b/runners/cli/tests/http.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createTargetClient } from "@agent-opfor/core/autonomous/target/http.js";
-import type { TargetConfig } from "@agent-opfor/core/autonomous/lib/types.js";
+import { createTargetClient } from "@keyvaluesystems/agent-opfor-core/autonomous/target/http.js";
+import type { TargetConfig } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
 
 type CapturedRequest = { url: string; init: RequestInit };
 

--- a/runners/cli/tests/knowledge.test.ts
+++ b/runners/cli/tests/knowledge.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { loadKnowledge } from "@agent-opfor/core/autonomous/knowledge/load.js";
+import { loadKnowledge } from "@keyvaluesystems/agent-opfor-core/autonomous/knowledge/load.js";
 
 test("loadKnowledge loads the bundled seed libraries", async () => {
   const kb = await loadKnowledge();

--- a/runners/cli/tests/leads.test.ts
+++ b/runners/cli/tests/leads.test.ts
@@ -6,9 +6,9 @@ import {
   addLead,
   markLead,
   forkThread,
-} from "@agent-opfor/core/autonomous/state/runLog.js";
-import { BudgetGuard } from "@agent-opfor/core/autonomous/lib/budget.js";
-import { SessionGate } from "@agent-opfor/core/lib/sessionGate.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
+import { BudgetGuard } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/budget.js";
+import { SessionGate } from "@keyvaluesystems/agent-opfor-core/lib/sessionGate.js";
 
 function baseLog() {
   return createRunLog({

--- a/runners/cli/tests/observe.test.ts
+++ b/runners/cli/tests/observe.test.ts
@@ -5,12 +5,12 @@ import {
   getOrCreateThread,
   forkThread,
   addLead,
-} from "@agent-opfor/core/autonomous/state/runLog.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 import {
   countsLine,
   threadTreeText,
   renderForest,
-} from "@agent-opfor/core/autonomous/state/observe.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/observe.js";
 
 function baseLog() {
   return createRunLog({

--- a/runners/cli/tests/progress.test.ts
+++ b/runners/cli/tests/progress.test.ts
@@ -4,7 +4,7 @@ import {
   createRunLog,
   getOrCreateThread,
   computeProgressSignal,
-} from "@agent-opfor/core/autonomous/state/runLog.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
 
 function baseLog() {
   return createRunLog({

--- a/runners/cli/tests/recordFinding.test.ts
+++ b/runners/cli/tests/recordFinding.test.ts
@@ -1,12 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { recordFindingTool } from "@agent-opfor/core/autonomous/tools/recordFinding.js";
-import { BudgetGuard } from "@agent-opfor/core/autonomous/lib/budget.js";
-import { SessionGate } from "@agent-opfor/core/lib/sessionGate.js";
-import { createRunLog, getOrCreateThread } from "@agent-opfor/core/autonomous/state/runLog.js";
-import type { RunContext } from "@agent-opfor/core/autonomous/orchestrator/context.js";
-import type { HuntOptions } from "@agent-opfor/core/autonomous/lib/types.js";
-import type { VulnClass } from "@agent-opfor/core/autonomous/knowledge/types.js";
+import { recordFindingTool } from "@keyvaluesystems/agent-opfor-core/autonomous/tools/recordFinding.js";
+import { BudgetGuard } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/budget.js";
+import { SessionGate } from "@keyvaluesystems/agent-opfor-core/lib/sessionGate.js";
+import {
+  createRunLog,
+  getOrCreateThread,
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
+import type { RunContext } from "@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/context.js";
+import type { HuntOptions } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
+import type { VulnClass } from "@keyvaluesystems/agent-opfor-core/autonomous/knowledge/types.js";
 
 function ctxWith(): RunContext {
   const log = createRunLog({

--- a/runners/cli/tests/runlog.test.ts
+++ b/runners/cli/tests/runlog.test.ts
@@ -5,8 +5,8 @@ import {
   getOrCreateThread,
   evidenceFoundInThread,
   normalizeForMatch,
-} from "@agent-opfor/core/autonomous/state/runLog.js";
-import { mapRunLogToReport } from "@agent-opfor/core/autonomous/report/mapRunLog.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
+import { mapRunLogToReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/mapRunLog.js";
 
 function baseLog() {
   return createRunLog({

--- a/runners/cli/tests/sendToTarget.test.ts
+++ b/runners/cli/tests/sendToTarget.test.ts
@@ -1,12 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { sendToTargetTool } from "@agent-opfor/core/autonomous/tools/sendToTarget.js";
-import { createTargetClient } from "@agent-opfor/core/autonomous/target/http.js";
-import { BudgetGuard } from "@agent-opfor/core/autonomous/lib/budget.js";
-import { SessionGate } from "@agent-opfor/core/lib/sessionGate.js";
-import { createRunLog } from "@agent-opfor/core/autonomous/state/runLog.js";
-import type { RunContext } from "@agent-opfor/core/autonomous/orchestrator/context.js";
-import type { HuntOptions } from "@agent-opfor/core/autonomous/lib/types.js";
+import { sendToTargetTool } from "@keyvaluesystems/agent-opfor-core/autonomous/tools/sendToTarget.js";
+import { createTargetClient } from "@keyvaluesystems/agent-opfor-core/autonomous/target/http.js";
+import { BudgetGuard } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/budget.js";
+import { SessionGate } from "@keyvaluesystems/agent-opfor-core/lib/sessionGate.js";
+import { createRunLog } from "@keyvaluesystems/agent-opfor-core/autonomous/state/runLog.js";
+import type { RunContext } from "@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/context.js";
+import type { HuntOptions } from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
 
 function stubFetch(reply: string): () => void {
   const original = globalThis.fetch;

--- a/runners/cli/ui/package-lock.json
+++ b/runners/cli/ui/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agent-opfor/autonomous-ui",
+  "name": "@keyvaluesystems/agent-opfor-autonomous-ui",
   "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agent-opfor/autonomous-ui",
+      "name": "@keyvaluesystems/agent-opfor-autonomous-ui",
       "version": "0.9.0",
       "dependencies": {
         "react": "^19.1.0",

--- a/runners/cli/ui/package.json
+++ b/runners/cli/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/autonomous-ui",
+  "name": "@keyvaluesystems/agent-opfor-autonomous-ui",
   "private": true,
   "version": "0.9.0",
   "type": "module",

--- a/runners/extension/README.md
+++ b/runners/extension/README.md
@@ -58,28 +58,28 @@ The extension will:
 
 ## Module Structure
 
-| File                   | Responsibility                                                     |
-| ---------------------- | ------------------------------------------------------------------ |
-| `service_worker.js`    | Entry point — message routing                                      |
-| `orchestrator.js`      | Main run loop: locate → attack → extract → judge                   |
-| `chatLocator.js`       | LLM-driven chat widget detection using accessibility tree          |
-| `frameDiscovery.js`    | Frame collection, scoring, and chat-frame selection                |
-| `domTarget.js`         | Wraps DOM send/extract as a core `AgentTarget`                     |
-| `domActions.js`        | DOM interaction via `chrome.scripting.executeScript`               |
-| `responseExtractor.js` | Smart polling extractor for bot responses                          |
-| `llmUiActions.js`      | DOM-specific LLM helpers                                           |
-| `llm.js`               | Direct LLM API calls for extension context                         |
-| `agentContext.js`      | Resolves agent business context from page content                  |
-| `catalog.js`           | `catalog.json` loading and evaluator/suite lookups                 |
-| `config.js`            | LLM profile loading from storage                                   |
-| `storage.js`           | `chrome.storage.local` read/write helpers                          |
-| `state.js`             | Shared mutable run state (`OPFOR_STOP`, abort controller)          |
-| `providers.js`         | LLM provider configurations                                        |
-| `utils.js`             | Utility functions (`sleep`, `formatTranscript`, etc.)              |
-| `popup.js`             | Extension popup UI logic                                           |
-| `sidepanel-*.js`       | Side panel UI components                                           |
-| `dist/core.bundle.js`  | Browser bundle of `@agent-opfor/core` (attack + judge engine)      |
-| `frame_*.js`           | Frame scripts injected into page contexts (standalone, no imports) |
+| File                   | Responsibility                                                                |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| `service_worker.js`    | Entry point — message routing                                                 |
+| `orchestrator.js`      | Main run loop: locate → attack → extract → judge                              |
+| `chatLocator.js`       | LLM-driven chat widget detection using accessibility tree                     |
+| `frameDiscovery.js`    | Frame collection, scoring, and chat-frame selection                           |
+| `domTarget.js`         | Wraps DOM send/extract as a core `AgentTarget`                                |
+| `domActions.js`        | DOM interaction via `chrome.scripting.executeScript`                          |
+| `responseExtractor.js` | Smart polling extractor for bot responses                                     |
+| `llmUiActions.js`      | DOM-specific LLM helpers                                                      |
+| `llm.js`               | Direct LLM API calls for extension context                                    |
+| `agentContext.js`      | Resolves agent business context from page content                             |
+| `catalog.js`           | `catalog.json` loading and evaluator/suite lookups                            |
+| `config.js`            | LLM profile loading from storage                                              |
+| `storage.js`           | `chrome.storage.local` read/write helpers                                     |
+| `state.js`             | Shared mutable run state (`OPFOR_STOP`, abort controller)                     |
+| `providers.js`         | LLM provider configurations                                                   |
+| `utils.js`             | Utility functions (`sleep`, `formatTranscript`, etc.)                         |
+| `popup.js`             | Extension popup UI logic                                                      |
+| `sidepanel-*.js`       | Side panel UI components                                                      |
+| `dist/core.bundle.js`  | Browser bundle of `@keyvaluesystems/agent-opfor-core` (attack + judge engine) |
+| `frame_*.js`           | Frame scripts injected into page contexts (standalone, no imports)            |
 
 Frame scripts (`frame_*.js`) are injected via `chrome.scripting.executeScript()` into page contexts and **cannot use ES module imports** — they remain standalone files.
 

--- a/runners/extension/package.json
+++ b/runners/extension/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/extension",
+  "name": "@keyvaluesystems/agent-opfor-extension",
   "version": "0.9.0",
   "description": "Opfor browser extension (MV3) — chat UI injector for live testing",
   "license": "Apache-2.0",

--- a/runners/mcp/README.md
+++ b/runners/mcp/README.md
@@ -1,0 +1,37 @@
+# @keyvaluesystems/agent-opfor-mcp
+
+Opfor MCP server — expose red-team tools to any MCP-compatible AI agent (Cursor, Claude Desktop, etc.).
+
+## Installation
+
+Add to your MCP host config (e.g. `.cursor/mcp.json` or `claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "opfor": {
+      "command": "npx",
+      "args": ["-y", "@keyvaluesystems/agent-opfor-mcp"],
+      "env": {
+        "ANTHROPIC_API_KEY": "<your-key>"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+| Tool                    | Description                              |
+| ----------------------- | ---------------------------------------- |
+| `opfor_list_evaluators` | List available evaluators and suites     |
+| `opfor_setup`           | Generate a red-team config interactively |
+| `opfor_run`             | Run a full evaluation and return results |
+
+## Documentation
+
+See [docs.agentopfor.ai/mcp](https://docs.agentopfor.ai/mcp) for full MCP server reference.
+
+## License
+
+Apache-2.0

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -20,7 +20,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepare": "echo 'run npm run build from the repo root'",
     "start": "node dist/index.js",
-    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "prepack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
   },
   "publishConfig": {

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -8,16 +8,25 @@
     "opfor-agent-mcp": "./dist/index.js"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "data/",
+    "evaluators/",
+    "suites/",
+    "atlas-data/"
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -rf dist && node scripts/bundle.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepare": "echo 'run npm run build from the repo root'",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "dependencies": {
-    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@ai-sdk/anthropic": "^2.0.77",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",
@@ -30,7 +39,9 @@
     "zod": "^3.0.0"
   },
   "devDependencies": {
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@types/node": "^24.0.0",
+    "esbuild": "^0.25.0",
     "tsx": "^4.20.0",
     "typescript": "^5.8.3"
   }

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/mcp",
+  "name": "@keyvaluesystems/agent-opfor-mcp",
   "version": "0.9.0",
   "description": "Opfor MCP server — expose red team tools to any MCP-compatible AI agent",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agent-opfor/core": "^0.9.0",
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@ai-sdk/anthropic": "^2.0.77",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -17,7 +17,7 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@agent-opfor/core": "*",
+    "@agent-opfor/core": "^0.9.0",
     "@ai-sdk/anthropic": "^2.0.77",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",

--- a/runners/mcp/scripts/bundle.mjs
+++ b/runners/mcp/scripts/bundle.mjs
@@ -1,0 +1,23 @@
+import { build } from "esbuild";
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+await build({
+  entryPoints: [resolve(__dirname, "../src/index.ts")],
+  outfile: resolve(__dirname, "../dist/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "node20",
+  external: ["node:*"],
+  sourcemap: true,
+  banner: {
+    js: [
+      "#!/usr/bin/env node",
+      "import { createRequire } from 'module';",
+      "const require = createRequire(import.meta.url);",
+    ].join("\n"),
+  },
+});

--- a/runners/mcp/src/index.ts
+++ b/runners/mcp/src/index.ts
@@ -11,13 +11,13 @@ import { readFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
-import { loadSkillCatalog } from "@agent-opfor/core/config/loadSkillCatalog.js";
-import { loadCatalog as loadMcpCatalog } from "@agent-opfor/core/catalog/loadCatalog.js";
-import { runAll } from "@agent-opfor/core/execute/runAll.js";
-import { writeReport } from "@agent-opfor/core/report/buildReport.js";
-import { PROVIDERS, type ProviderName } from "@agent-opfor/core/config/types.js";
-import type { RunConfig } from "@agent-opfor/core/execute/types.js";
-import { normalizeEffort } from "@agent-opfor/core/execute/effortCompat.js";
+import { loadSkillCatalog } from "@keyvaluesystems/agent-opfor-core/config/loadSkillCatalog.js";
+import { loadCatalog as loadMcpCatalog } from "@keyvaluesystems/agent-opfor-core/catalog/loadCatalog.js";
+import { runAll } from "@keyvaluesystems/agent-opfor-core/execute/runAll.js";
+import { writeReport } from "@keyvaluesystems/agent-opfor-core/report/buildReport.js";
+import { PROVIDERS, type ProviderName } from "@keyvaluesystems/agent-opfor-core/config/types.js";
+import type { RunConfig } from "@keyvaluesystems/agent-opfor-core/execute/types.js";
+import { normalizeEffort } from "@keyvaluesystems/agent-opfor-core/execute/effortCompat.js";
 
 function readVersion(): string {
   const pkgUrl = new URL("../package.json", import.meta.url);

--- a/runners/mcp/src/index.ts
+++ b/runners/mcp/src/index.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 // Load .env from the project the MCP server is running against.
 import { config as loadDotenv } from "dotenv";
 loadDotenv();

--- a/runners/sdk/README.md
+++ b/runners/sdk/README.md
@@ -47,7 +47,7 @@ await opfor.report(results).json("./report.json");
 
 ## Documentation
 
-See [docs/sdk.md](../../docs/sdk.md) for full documentation.
+See [docs.agentopfor.ai/sdk](https://docs.agentopfor.ai/sdk) for full documentation.
 
 ## License
 

--- a/runners/sdk/README.md
+++ b/runners/sdk/README.md
@@ -1,11 +1,11 @@
-# @agent-opfor/sdk
+# @keyvaluesystems/agent-opfor-sdk
 
 Opfor SDK — programmatic adversarial testing for AI systems.
 
 ## Installation
 
 ```bash
-npm install @agent-opfor/sdk
+npm install @keyvaluesystems/agent-opfor-sdk
 ```
 
 ## Quick Start
@@ -13,7 +13,7 @@ npm install @agent-opfor/sdk
 ### Functional API
 
 ```typescript
-import { run, report } from "@agent-opfor/sdk";
+import { run, report } from "@keyvaluesystems/agent-opfor-sdk";
 
 const results = await run({
   target: {
@@ -31,7 +31,7 @@ await report(results).html("./report.html");
 ### Class-based API
 
 ```typescript
-import { Opfor } from "@agent-opfor/sdk";
+import { Opfor } from "@keyvaluesystems/agent-opfor-sdk";
 
 const opfor = new Opfor({
   apiKey: process.env.ANTHROPIC_API_KEY,

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -22,7 +22,7 @@
     "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "*"
+    "@agent-opfor/core": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/sdk",
+  "name": "@keyvaluesystems/agent-opfor-sdk",
   "version": "0.9.0",
   "description": "Opfor SDK — programmatic adversarial testing for AI systems",
   "license": "Apache-2.0",
@@ -22,7 +22,7 @@
     "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
-    "@agent-opfor/core": "^0.9.0"
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -13,19 +13,27 @@
     }
   },
   "files": [
-    "dist/"
+    "dist/",
+    "data/",
+    "evaluators/",
+    "suites/",
+    "atlas-data/"
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
-    "build": "tsc -p tsconfig.json",
+    "build": "tsup",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "test": "tsx --test tests/*.test.ts"
+    "test": "tsx --test tests/*.test.ts",
+    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
   },
-  "dependencies": {
-    "@keyvaluesystems/agent-opfor-core": "^0.9.0"
+  "publishConfig": {
+    "access": "public"
   },
   "devDependencies": {
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@types/node": "^24.0.0",
+    "tsup": "^8.0.0",
     "tsx": "^4.20.0",
     "typescript": "^5.8.3"
   },

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -24,7 +24,7 @@
     "build": "tsup",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "tsx --test tests/*.test.ts",
-    "prepack": "cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
+    "prepack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
   },
   "publishConfig": {

--- a/runners/sdk/src/catalog.ts
+++ b/runners/sdk/src/catalog.ts
@@ -1,5 +1,5 @@
-import { loadSkillCatalog } from "@agent-opfor/core/config/loadSkillCatalog.js";
-import { loadCatalog } from "@agent-opfor/core/catalog/loadCatalog.js";
+import { loadSkillCatalog } from "@keyvaluesystems/agent-opfor-core/config/loadSkillCatalog.js";
+import { loadCatalog } from "@keyvaluesystems/agent-opfor-core/catalog/loadCatalog.js";
 import type { SuiteInfo, EvaluatorInfo, ListEvaluatorsOptions } from "./types.js";
 
 /**

--- a/runners/sdk/src/hunt.ts
+++ b/runners/sdk/src/hunt.ts
@@ -7,14 +7,14 @@
 
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { runAutonomous } from "@agent-opfor/core/autonomous/orchestrator/run.js";
-import { writeAutonomousReport } from "@agent-opfor/core/autonomous/report/writeReport.js";
+import { runAutonomous } from "@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/run.js";
+import { writeAutonomousReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js";
 import type {
   HuntOptions as CoreHuntOptions,
   TargetConfig as CoreTargetConfig,
   TargetMode,
-} from "@agent-opfor/core/autonomous/lib/types.js";
-import type { AutonomousReport } from "@agent-opfor/core/autonomous/report/types.js";
+} from "@keyvaluesystems/agent-opfor-core/autonomous/lib/types.js";
+import type { AutonomousReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/types.js";
 import type {
   HuntOptions,
   HuntResults,
@@ -32,7 +32,7 @@ import type {
  *
  * @example
  * ```typescript
- * import { hunt } from "@agent-opfor/sdk";
+ * import { hunt } from "@keyvaluesystems/agent-opfor-sdk";
  *
  * const results = await hunt({
  *   target: {

--- a/runners/sdk/src/run.ts
+++ b/runners/sdk/src/run.ts
@@ -1,11 +1,11 @@
-import { runAll } from "@agent-opfor/core";
+import { runAll } from "@keyvaluesystems/agent-opfor-core";
 import type {
   RunConfig,
   AgentTargetConfig,
   McpTargetConfig,
   EvaluatorSelection,
-} from "@agent-opfor/core";
-import type { LlmConfig, ProviderName } from "@agent-opfor/core/config/types.js";
+} from "@keyvaluesystems/agent-opfor-core";
+import type { LlmConfig, ProviderName } from "@keyvaluesystems/agent-opfor-core/config/types.js";
 import type {
   RunOptions,
   RunResults,
@@ -154,7 +154,9 @@ function getDefaultApiKeyEnv(provider: ProviderName): string {
   return envVars[provider] ?? "ANTHROPIC_API_KEY";
 }
 
-function transformReport(coreReport: import("@agent-opfor/core").UnifiedRunReport): RunResults {
+function transformReport(
+  coreReport: import("@keyvaluesystems/agent-opfor-core").UnifiedRunReport
+): RunResults {
   const findings = extractFindings(coreReport);
   const evaluators = coreReport.evaluators.map(transformEvaluatorResult);
 
@@ -173,7 +175,9 @@ function transformReport(coreReport: import("@agent-opfor/core").UnifiedRunRepor
   };
 }
 
-function extractFindings(report: import("@agent-opfor/core").UnifiedRunReport): Finding[] {
+function extractFindings(
+  report: import("@keyvaluesystems/agent-opfor-core").UnifiedRunReport
+): Finding[] {
   const findings: Finding[] = [];
 
   for (const evaluator of report.evaluators) {
@@ -197,7 +201,7 @@ function extractFindings(report: import("@agent-opfor/core").UnifiedRunReport): 
 }
 
 function transformEvaluatorResult(
-  core: import("@agent-opfor/core").EvaluatorResult
+  core: import("@keyvaluesystems/agent-opfor-core").EvaluatorResult
 ): EvaluatorResult {
   return {
     evaluatorId: core.evaluatorId,
@@ -213,7 +217,9 @@ function transformEvaluatorResult(
   };
 }
 
-function transformAttackResult(core: import("@agent-opfor/core").AttackResult): AttackResult {
+function transformAttackResult(
+  core: import("@keyvaluesystems/agent-opfor-core").AttackResult
+): AttackResult {
   const prompt = core.kind === "agent" ? (core.prompt ?? "") : (core.toolName ?? "");
   const response = core.kind === "agent" ? (core.response ?? "") : (core.toolResponse ?? "");
   return {

--- a/runners/sdk/src/types.ts
+++ b/runners/sdk/src/types.ts
@@ -1,5 +1,9 @@
-import type { Effort, UnifiedRunReport } from "@agent-opfor/core";
-import type { TelemetryConfig, LlmConfig, ProviderName } from "@agent-opfor/core/config/types.js";
+import type { Effort, UnifiedRunReport } from "@keyvaluesystems/agent-opfor-core";
+import type {
+  TelemetryConfig,
+  LlmConfig,
+  ProviderName,
+} from "@keyvaluesystems/agent-opfor-core/config/types.js";
 
 // ---------------------------------------------------------------------------
 // Target Configuration

--- a/runners/sdk/src/types.ts
+++ b/runners/sdk/src/types.ts
@@ -1,10 +1,3 @@
-import type { Effort, UnifiedRunReport } from "@keyvaluesystems/agent-opfor-core";
-import type {
-  TelemetryConfig,
-  LlmConfig,
-  ProviderName,
-} from "@keyvaluesystems/agent-opfor-core/config/types.js";
-
 // ---------------------------------------------------------------------------
 // Target Configuration
 // ---------------------------------------------------------------------------
@@ -355,7 +348,102 @@ export interface HuntResults {
 }
 
 // ---------------------------------------------------------------------------
-// Re-exports from core
+// Types inlined from core — keeps the published .d.ts free of
+// @keyvaluesystems/agent-opfor-core references (core is not published to npm)
 // ---------------------------------------------------------------------------
 
-export type { TelemetryConfig, LlmConfig, ProviderName, Effort, UnifiedRunReport };
+export type Effort = "adaptive" | "comprehensive";
+
+export type ProviderName =
+  | "openai"
+  | "anthropic"
+  | "groq"
+  | "google"
+  | "deepseek"
+  | "azure"
+  | "openai-compatible";
+
+export interface LlmConfig {
+  provider: ProviderName;
+  model: string;
+  apiKeyEnv?: string;
+  baseURL?: string;
+}
+
+export type TelemetryProviderId = "none" | "langfuse" | "netra";
+
+export interface TelemetryPropagationConfig {
+  headers?: Record<string, string>;
+  traceIdBodyField?: string;
+  traceIdStrategy?: "per-attack" | "per-run";
+  traceIdPrefix?: string;
+}
+
+export interface LangfuseTraceSelectionConfig {
+  setupTraceIds?: string[];
+  lookbackHours?: number;
+  fromTimestamp?: string;
+  toTimestamp?: string;
+  userId?: string;
+  sessionId?: string;
+  name?: string;
+  version?: string;
+  release?: string;
+  tags?: string[];
+  environment?: string | string[];
+  orderBy?: string;
+  filter?: Record<string, unknown>[];
+  observationName?: string;
+  observationType?: "GENERATION" | "SPAN" | "EVENT";
+  listLimit?: number;
+  listMaxPages?: number;
+  fields?: string;
+}
+
+export interface NetraTraceSelectionConfig {
+  setupTraceIds?: string[];
+  lookbackHours?: number;
+  fromTime?: string;
+  toTime?: string;
+  sessionId?: string;
+  userId?: string;
+  environment?: string;
+  listLimit?: number;
+  listMaxPages?: number;
+}
+
+export interface LangfuseTelemetryConfig {
+  baseUrl?: string;
+  baseUrlEnv?: string;
+  publicKeyEnv?: string;
+  secretKeyEnv?: string;
+  traceSelection?: LangfuseTraceSelectionConfig;
+  traceDetailFields?: string;
+  observationV2Fields?: string;
+  observationV2MaxPages?: number;
+  traceCurationListJsonMaxChars?: number;
+  traceSummarySourceJsonMaxChars?: number;
+  traceSummaryForAttackMaxChars?: number;
+}
+
+export interface NetraTelemetryConfig {
+  baseUrl?: string;
+  baseUrlEnv?: string;
+  apiKeyEnv?: string;
+  traceSelection?: NetraTraceSelectionConfig;
+  traceCurationListJsonMaxChars?: number;
+  traceSummarySourceJsonMaxChars?: number;
+  traceSummaryForAttackMaxChars?: number;
+}
+
+export interface TelemetryConfig {
+  provider: TelemetryProviderId;
+  langfuse?: LangfuseTelemetryConfig;
+  netra?: NetraTelemetryConfig;
+  enrichJudgeFromTrace?: boolean;
+  traceFetchInitialDelayMs?: number;
+  traceFetchMaxAttempts?: number;
+  traceFetchRetryDelayMs?: number;
+  enrichJudgeTraceJsonMaxChars?: number;
+  propagation?: TelemetryPropagationConfig;
+}

--- a/runners/sdk/tests/catalog.test.ts
+++ b/runners/sdk/tests/catalog.test.ts
@@ -6,7 +6,7 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { setEnvProvider } from "@agent-opfor/core/lib/env.js";
+import { setEnvProvider } from "@keyvaluesystems/agent-opfor-core/lib/env.js";
 
 setEnvProvider(() => "fake-test-api-key");
 

--- a/runners/sdk/tests/hunt.test.ts
+++ b/runners/sdk/tests/hunt.test.ts
@@ -10,7 +10,7 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { setEnvProvider } from "@agent-opfor/core/lib/env.js";
+import { setEnvProvider } from "@keyvaluesystems/agent-opfor-core/lib/env.js";
 
 setEnvProvider(() => "fake-test-api-key");
 

--- a/runners/sdk/tests/opfor-class.test.ts
+++ b/runners/sdk/tests/opfor-class.test.ts
@@ -6,7 +6,7 @@
 
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { setEnvProvider } from "@agent-opfor/core/lib/env.js";
+import { setEnvProvider } from "@keyvaluesystems/agent-opfor-core/lib/env.js";
 
 setEnvProvider(() => "fake-test-api-key");
 

--- a/runners/sdk/tests/report.test.ts
+++ b/runners/sdk/tests/report.test.ts
@@ -8,7 +8,7 @@ import { test, describe, after } from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, unlinkSync, readFileSync } from "node:fs";
 import path from "node:path";
-import { setEnvProvider } from "@agent-opfor/core/lib/env.js";
+import { setEnvProvider } from "@keyvaluesystems/agent-opfor-core/lib/env.js";
 
 setEnvProvider(() => "fake-test-api-key");
 

--- a/runners/sdk/tests/run.test.ts
+++ b/runners/sdk/tests/run.test.ts
@@ -14,7 +14,7 @@ import { test, after, before, describe } from "node:test";
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import type { Server } from "node:http";
-import { setEnvProvider } from "@agent-opfor/core/lib/env.js";
+import { setEnvProvider } from "@keyvaluesystems/agent-opfor-core/lib/env.js";
 
 // Set fake env before importing SDK (which imports core)
 setEnvProvider(() => "fake-test-api-key");

--- a/runners/sdk/tsup.config.ts
+++ b/runners/sdk/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  clean: true,
+  dts: {
+    // composite: true in tsconfig conflicts with tsup's isolated DTS build
+    compilerOptions: { composite: false, incremental: false },
+  },
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  external: ["node:*"],
+  sourcemap: true,
+});

--- a/scripts/smoke-pack.ts
+++ b/scripts/smoke-pack.ts
@@ -1,0 +1,105 @@
+/**
+ * Packed-tarball smoke test.
+ *
+ * Builds the real npm tarball for @keyvaluesystems/agent-opfor-core (via `npm pack`, which runs
+ * the package's prepack/postpack), installs it into a clean throwaway project
+ * *outside* the monorepo, and exercises the runtime code paths that rely on
+ * on-disk data files. This is the only check that catches "works in the
+ * monorepo, breaks once published" bugs — where code resolves data via paths
+ * that are only valid when every package shares one source tree.
+ *
+ * Specifically it verifies:
+ *   - the evaluator catalog loads (which reads + validates against the vendored
+ *     MITRE ATLAS data), and
+ *   - the autonomous seed knowledge (personas / strategies / vuln-classes) loads.
+ *
+ * Usage:
+ *   npm run build && npm run smoke:pack
+ *
+ * Exits non-zero on any failure so it can gate a release in CI.
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CORE_DIR = path.join(REPO_ROOT, "core");
+
+function run(cmd: string, args: string[], cwd: string): string {
+  return execFileSync(cmd, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+function fail(msg: string): never {
+  console.error(`\n❌ Smoke test FAILED: ${msg}`);
+  process.exit(1);
+}
+
+const corePkg = JSON.parse(readFileSync(path.join(CORE_DIR, "package.json"), "utf8")) as {
+  name: string;
+  version: string;
+};
+
+const workDir = mkdtempSync(path.join(tmpdir(), "opfor-smoke-"));
+
+try {
+  console.log(`Packing ${corePkg.name}@${corePkg.version} …`);
+  // `npm pack` prints the tarball filename as its final stdout line.
+  const packOut = run("npm", ["pack", "--pack-destination", workDir], CORE_DIR).trim();
+  const tarball = packOut.split("\n").pop()?.trim();
+  if (!tarball) fail("could not determine packed tarball filename");
+  const tarballPath = path.join(workDir, tarball as string);
+
+  console.log("Installing tarball into a clean project (no monorepo around it) …");
+  run("npm", ["init", "-y"], workDir);
+  run("npm", ["install", tarballPath], workDir);
+
+  // Import via the package's *public* export subpaths — exactly what a consumer hits.
+  const testFile = path.join(workDir, "smoke.mjs");
+  writeFileSync(
+    testFile,
+    `
+import { loadEvaluatorCatalog } from "${corePkg.name}/catalog/loadEvaluatorCatalog.js";
+import { loadKnowledge } from "${corePkg.name}/autonomous/knowledge/load.js";
+
+const cat = await loadEvaluatorCatalog("agent");
+const kb = await loadKnowledge();
+
+const out = {
+  evaluators: cat.evaluators.length,
+  suites: cat.suites.length,
+  personas: kb.personas.length,
+  strategies: kb.strategies.length,
+  vulnClasses: kb.vulnClasses.length,
+};
+console.log(JSON.stringify(out));
+`,
+    "utf8"
+  );
+
+  const resultRaw = run("node", [testFile], workDir).trim();
+  const result = JSON.parse(resultRaw.split("\n").pop() as string) as Record<string, number>;
+
+  console.log("Loaded from clean install:", result);
+
+  const checks: Array<[string, boolean]> = [
+    ["evaluators > 0 (catalog + ATLAS data resolved)", result.evaluators > 0],
+    ["suites > 0", result.suites > 0],
+    ["personas > 0 (seed knowledge resolved)", result.personas > 0],
+    ["strategies > 0", result.strategies > 0],
+    ["vulnClasses > 0", result.vulnClasses > 0],
+  ];
+
+  const failures = checks.filter(([, ok]) => !ok).map(([name]) => name);
+  if (failures.length > 0) fail(`empty results for: ${failures.join(", ")}`);
+
+  console.log("\n✅ Smoke test PASSED — packed tarball works from a clean install");
+} catch (e: unknown) {
+  const msg = e instanceof Error ? e.message : String(e);
+  fail(msg);
+} finally {
+  rmSync(workDir, { recursive: true, force: true });
+}

--- a/tests/e2e/agents/customer-support/Dockerfile
+++ b/tests/e2e/agents/customer-support/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json package-lock.json ./
 COPY tests/e2e/agents/customer-support/package.json ./tests/e2e/agents/customer-support/
 
 # Install only this workspace package's deps (devDependencies included — needed at runtime via tsx)
-RUN npm install --workspace=@agent-opfor/test-agent-customer-support --ignore-scripts
+RUN npm install --workspace=@keyvaluesystems/agent-opfor-test-agent-customer-support --ignore-scripts
 
 # Copy agent source
 COPY tests/e2e/agents/customer-support/src ./tests/e2e/agents/customer-support/src

--- a/tests/e2e/agents/customer-support/package-lock.json
+++ b/tests/e2e/agents/customer-support/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agent-opfor/test-agent-customer-support",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-customer-support",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agent-opfor/test-agent-customer-support",
+      "name": "@keyvaluesystems/agent-opfor-test-agent-customer-support",
       "version": "0.1.0",
       "devDependencies": {
         "@langchain/anthropic": "^1.3.29",

--- a/tests/e2e/agents/customer-support/package.json
+++ b/tests/e2e/agents/customer-support/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/test-agent-customer-support",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-customer-support",
   "version": "0.9.0",
   "description": "Customer support test agent with PostgreSQL — tests BOLA, BFLA, RBAC, PII, and SQL injection evaluators",
   "private": true,

--- a/tests/e2e/agents/vanilla-chat/Dockerfile
+++ b/tests/e2e/agents/vanilla-chat/Dockerfile
@@ -7,7 +7,7 @@ COPY package.json package-lock.json ./
 COPY tests/e2e/agents/vanilla-chat/package.json ./tests/e2e/agents/vanilla-chat/
 
 # Install only this workspace package's deps (devDependencies included — needed at runtime via tsx)
-RUN npm install --workspace=@agent-opfor/test-agent-vanilla-chat --ignore-scripts
+RUN npm install --workspace=@keyvaluesystems/agent-opfor-test-agent-vanilla-chat --ignore-scripts
 
 # Copy agent source
 COPY tests/e2e/agents/vanilla-chat/src ./tests/e2e/agents/vanilla-chat/src

--- a/tests/e2e/agents/vanilla-chat/package-lock.json
+++ b/tests/e2e/agents/vanilla-chat/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agent-opfor/test-agent-vanilla-chat",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-vanilla-chat",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agent-opfor/test-agent-vanilla-chat",
+      "name": "@keyvaluesystems/agent-opfor-test-agent-vanilla-chat",
       "version": "0.1.0",
       "dependencies": {
         "langchain": "1.4.2"

--- a/tests/e2e/agents/vanilla-chat/package.json
+++ b/tests/e2e/agents/vanilla-chat/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/test-agent-vanilla-chat",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-vanilla-chat",
   "version": "0.9.0",
   "description": "Vanilla chat test agent — used for local developer testing of Opfor evaluators",
   "private": true,

--- a/tests/e2e/agents/vulnerable-memory/package-lock.json
+++ b/tests/e2e/agents/vulnerable-memory/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agent-opfor/test-agent-vulnerable-memory",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-vulnerable-memory",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agent-opfor/test-agent-vulnerable-memory",
+      "name": "@keyvaluesystems/agent-opfor-test-agent-vulnerable-memory",
       "version": "0.1.0",
       "devDependencies": {
         "@langchain/anthropic": "^1.3.29",

--- a/tests/e2e/agents/vulnerable-memory/package.json
+++ b/tests/e2e/agents/vulnerable-memory/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/test-agent-vulnerable-memory",
+  "name": "@keyvaluesystems/agent-opfor-test-agent-vulnerable-memory",
   "version": "0.9.0",
   "description": "Intentionally vulnerable agent — accepts and persists user-injected 'policies' into a global knowledge base across sessions",
   "private": true,

--- a/tests/e2e/mcp/vulnerable-server/package-lock.json
+++ b/tests/e2e/mcp/vulnerable-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@agent-opfor/test-mcp-vulnerable",
+  "name": "@keyvaluesystems/agent-opfor-test-mcp-vulnerable",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@agent-opfor/test-mcp-vulnerable",
+      "name": "@keyvaluesystems/agent-opfor-test-mcp-vulnerable",
       "version": "0.1.0",
       "devDependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/tests/e2e/mcp/vulnerable-server/package.json
+++ b/tests/e2e/mcp/vulnerable-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@agent-opfor/test-mcp-vulnerable",
+  "name": "@keyvaluesystems/agent-opfor-test-mcp-vulnerable",
   "version": "0.9.0",
   "description": "Intentionally vulnerable MCP server for opfor testing — DO NOT deploy",
   "private": true,


### PR DESCRIPTION
## Problem

The three runner packages (\`@keyvaluesystems/agent-opfor-cli\`, \`@keyvaluesystems/agent-opfor-mcp\`, \`@keyvaluesystems/agent-opfor-sdk\`) could not be published to npm. Three blockers:

1. All runners declared \`@keyvaluesystems/agent-opfor-core\` as a runtime dependency — a wildcard resolved by npm workspaces locally but unresolvable from an external registry. Core is intentionally not published.
2. The \`evaluators/\`, \`suites/\`, and \`skills/\` data directories were not included in runner packages. After installing from npm, \`getRepoRoot()\` in \`evaluatorsLayout.ts\` resolved to the wrong path, so evaluator discovery would fail at runtime.
3. None of the scoped packages had \`publishConfig: { access: \"public\" }\`, which is required for \`@scope/*\` packages on npm.

## Solution

**Bundle core inline instead of resolving it at runtime**
- CLI and MCP runners use esbuild to produce a single \`dist/index.js\` that inlines all of core's compiled output. No runtime npm resolution of core needed.
- SDK uses tsup (wraps esbuild + tsc declaration emit) to produce \`dist/index.js\` + \`dist/index.d.ts\`. tsup is used instead of esbuild because SDK consumers need TypeScript type declarations.
- Core moved from \`dependencies\` → \`devDependencies\` in all three runners.

**Ship data files with each runner**
- \`prepack\` scripts copy \`evaluators/\`, \`suites/\`, \`atlas-data/\`, and (for MCP/SDK) \`data/\` into each runner directory before packing.
- \`postpack\` scripts clean them up after.
- All three runners' \`files\` arrays updated to include these directories.

**Fix \`getRepoRoot()\` path resolution**
- Added a one-level-up check so bundled runners (bundle at \`dist/\`) find data at the package root (\`../\`).
- Changed the existence probe from \`evaluators/\` to \`evaluators/agent/\` to avoid a false-positive against \`core/src/evaluators/\` (a TypeScript source directory, not the data directory).

**Pre-publish hardening**
- Added \`publishConfig: { access: \"public\" }\` to all three runners.
- Clean builds: \`rm -rf dist\` before esbuild runs; \`clean: true\` in tsup config.
- Created \`README.md\` for CLI and MCP runners (SDK already had one).
- Added \`LICENSE\` copy in all three \`prepack\` scripts.
- SDK \`types.ts\` now defines all types inline (no re-exports from core) so the published \`.d.ts\` has zero \`@keyvaluesystems/agent-opfor-core\` references.

## Checklist

- [x] \`npm run build\` passes
- [x] \`npm run typecheck\` passes
- [x] \`npm run lint\` passes
- [x] \`npm pack --dry-run\` on all three runners shows correct file layout with no core references
- [ ] \`npm run build:catalog:check\` passes _(if evaluators or suites changed)_
- [ ] Tested against a local target _(if evaluator added or changed)_
- [x] No secrets, \`.env\`, or \`.opfor/\` artifacts committed
- [x] PR title follows \`<type>: <what changed>\`

## Evaluator checklist _(skip if no evaluator added)_

N/A — no evaluators changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated package names and references across the CLI, SDK, MCP server, browser extension, and related docs.
  * Added bundled packaging and release support for published packages.
  * Added smoke testing for published package installs.

* **Bug Fixes**
  * Improved package loading so runtime data works in both packaged and monorepo layouts.
  * Made ATLAS validation fail gracefully with a warning instead of stopping loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->