### PR TITLE
chore: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## What changed and why

Adds `workflow_dispatch` trigger to the release-please workflow so it can be run manually from the Actions tab for testing and on-demand releases.

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] No secrets, `.env`, or `.opfor/` artifacts committed
- [x] PR title follows `<type>: <what changed>`

