### PR TITLE
fix: use simple tag format for release-please

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -12,6 +12,10 @@ jobs:
       - name: Validate branch name
         run: |
           BRANCH="${{ github.head_ref }}"
+          if [[ "$BRANCH" == release-please--* ]]; then
+            echo "✅ Skipping branch name check for release-please branch."
+            exit 0
+          fi
           PATTERN="^(feat|fix|docs|refactor|chore|test|perf)/.+"
           if [[ ! "$BRANCH" =~ $PATTERN ]]; then
             echo "❌ Branch name '$BRANCH' does not follow the convention."

--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,4 @@ runners/mcp/dist/
 runners/extension/catalog.json
 .opfor/
 *.json
+CHANGELOG.md

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "packages": {
     ".": {
       "release-type": "node",
+      "include-component-in-tag": false,
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "extra-files": [


### PR DESCRIPTION
## What changed and why

Three fixes for release-please integration:

1. **Tag format** — Adds `"include-component-in-tag": false` to `release-please-config.json` so it looks for `v0.9.0` instead of `agent-opfor-v0.9.0`. Without this, release-please can't find the existing tag and dumps the entire commit history into the changelog.

2. **Branch name check** — Exempts `release-please--*` branches from the branch naming convention check in `commit-lint.yml`. Release-please auto-creates branches that don't follow our `<type>/<description>` pattern.

3. **Prettier** — Adds `CHANGELOG.md` to `.prettierignore` since the auto-generated changelog doesn't match Prettier formatting.

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] No secrets, `.env`, or `.opfor/` artifacts committed
- [x] PR title follows `<type>: <what changed>`