### PR TITLE
fix: rename 'Risk Score' to 'Safety Score' in extension popup

### DIFF
--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -1244,7 +1244,7 @@ function generateHtmlReport(report) {
           <div class="eval-body">
             <div class="eval-meta-grid">
               <div class="meta-item"><div class="meta-k">Verdict</div><div class="meta-v ${verdictPass ? "pass-text" : "fail-text"}">${tr.verdict || "—"}</div></div>
-              <div class="meta-item"><div class="meta-k">Risk Score</div><div class="meta-v">${tr.score ?? "—"} / 10</div></div>
+              <div class="meta-item"><div class="meta-k">Safety Score</div><div class="meta-v">${tr.score ?? "—"} / 10</div></div>
               <div class="meta-item"><div class="meta-k">Confidence</div><div class="meta-v">${tr.confidence != null ? tr.confidence + "%" : "—"}</div></div>
               <div class="meta-item"><div class="meta-k">Severity</div><div class="meta-v"><span class="sev-tag" style="background:${sevColor}18;color:${sevColor};border-color:${sevColor}44">${escapeHtml(e.severity)}</span></div></div>
               ${
@@ -1655,7 +1655,7 @@ function generateHtmlReport(report) {
     <div class="results-table-wrap" style="margin-bottom:16px">
       <table class="results">
         <thead><tr>
-          <th>#</th><th>Evaluator</th><th>Severity</th><th>Verdict</th><th>Risk Score</th>
+          <th>#</th><th>Evaluator</th><th>Severity</th><th>Verdict</th><th>Safety Score</th>
         </tr></thead>
         <tbody>${tableRows || `<tr><td colspan="5" style="text-align:center;color:var(--muted);padding:24px">No evaluators executed.</td></tr>`}</tbody>
       </table>


### PR DESCRIPTION
## Problem

The extension popup labels the safety score as "Risk Score", which is misleading — the scale runs 0 (most critical) to 10 (safest), so higher is better, not worse.
## Solution

Explain your approach and any important design decisions.

Renamed both instances of "Risk Score" to "Safety Score" in `popup.js` to match the label already used in `render.ts`.

## Checklist

- [ ] `npm run build` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build:catalog:check` passes _(if evaluators or suites changed)_
- [ ] Tested against a local target _(if evaluator added or changed)_
- [ ] No secrets, `.env`, or `.opfor/` artifacts committed
- [ ] PR title follows `<type>: <what changed>` — e.g. `feat: add SSRF evaluator`

## Evaluator checklist _(skip if no evaluator added)_

- [ ] `id` is unique across all evaluators
- [ ] `pass_criteria` and `fail_criteria` are specific, not vague
- [ ] `severity` matches actual risk (`critical` = RCE / data breach)
- [ ] `standards` mapping is correct
- [ ] `.test.yaml` fixture included
