### PR TITLE
fix: declare mcp dep, add createRequire banner, fix atlas-data resolution for bundled runners

### DIFF
--- a/core/src/standards/atlas.ts
+++ b/core/src/standards/atlas.ts
@@ -33,14 +33,26 @@ interface AtlasYamlDoc {
  * - Monorepo dev: `<repo>/third_party/atlas-data/dist/ATLAS.yaml` (the git submodule), 3 levels up
  *   from `core/{src,dist}/standards/`.
  */
-function atlasYamlPath(): string {
+function atlasYamlPath(): string | undefined {
   const here = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
     path.resolve(here, "..", "atlas-data", "ATLAS.yaml"),
     path.resolve(here, "..", "..", "atlas-data", "ATLAS.yaml"),
     path.resolve(here, "..", "..", "..", "third_party", "atlas-data", "dist", "ATLAS.yaml"),
   ];
-  return candidates.find((p) => existsSync(p)) ?? candidates[candidates.length - 1];
+  return candidates.find((p) => existsSync(p));
+}
+
+function missingAtlasHelp(): string {
+  return [
+    "MITRE ATLAS data not found.",
+    "",
+    "Published package (cli / mcp / sdk): atlas-data/ is bundled at install time.",
+    "  Try reinstalling: npm install @keyvaluesystems/agent-opfor-cli  (or -mcp / -sdk)",
+    "",
+    "Monorepo checkout: initialize the atlas-data submodule with:",
+    "  git submodule update --init --recursive",
+  ].join("\n");
 }
 
 function missingSubmoduleHelp(atlasPath: string): string {
@@ -59,6 +71,9 @@ function missingSubmoduleHelp(atlasPath: string): string {
  */
 export async function loadAtlasTechniqueIndex(): Promise<Map<string, AtlasTechniqueMeta>> {
   const atlasPath = atlasYamlPath();
+  if (atlasPath === undefined) {
+    throw new Error(missingAtlasHelp());
+  }
   let raw: string;
   try {
     raw = await readFile(atlasPath, "utf8");

--- a/core/src/standards/atlas.ts
+++ b/core/src/standards/atlas.ts
@@ -25,20 +25,22 @@ interface AtlasYamlDoc {
 }
 
 /**
- * Resolve the ATLAS YAML. Two layouts are supported:
- * - Published package: `<core>/atlas-data/ATLAS.yaml` (vendored into the tarball at pack time).
- * - Monorepo dev: `<repo>/third_party/atlas-data/dist/ATLAS.yaml` (the git submodule).
- *
- * This module is at `core/{src,dist}/standards/atlas.{ts,js}`, so the package root is 2 levels
- * up and the repo root is 3 levels up — true whether run from `src` (tsx) or `dist` (compiled).
+ * Resolve the ATLAS YAML. Three layouts are supported, tried in order:
+ * - Bundled runner (cli/mcp/sdk): the runner's esbuild/tsup bundle flattens this module to
+ *   `<pkg>/dist/*.js`, so `atlas-data/` (vendored at pack time) is 1 level up: `<pkg>/atlas-data/ATLAS.yaml`.
+ * - Published core package: this module is at `core/dist/standards/atlas.js`, so `atlas-data/`
+ *   (vendored at pack time) is 2 levels up: `<core>/atlas-data/ATLAS.yaml`.
+ * - Monorepo dev: `<repo>/third_party/atlas-data/dist/ATLAS.yaml` (the git submodule), 3 levels up
+ *   from `core/{src,dist}/standards/`.
  */
 function atlasYamlPath(): string {
   const here = path.dirname(fileURLToPath(import.meta.url));
-  const packageLocal = path.resolve(here, "..", "..", "atlas-data", "ATLAS.yaml");
-  if (existsSync(packageLocal)) {
-    return packageLocal;
-  }
-  return path.resolve(here, "..", "..", "..", "third_party", "atlas-data", "dist", "ATLAS.yaml");
+  const candidates = [
+    path.resolve(here, "..", "atlas-data", "ATLAS.yaml"),
+    path.resolve(here, "..", "..", "atlas-data", "ATLAS.yaml"),
+    path.resolve(here, "..", "..", "..", "third_party", "atlas-data", "dist", "ATLAS.yaml"),
+  ];
+  return candidates.find((p) => existsSync(p)) ?? candidates[candidates.length - 1];
 }
 
 function missingSubmoduleHelp(atlasPath: string): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7248,6 +7248,9 @@
       "name": "@keyvaluesystems/agent-opfor-sdk",
       "version": "0.9.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
       "devDependencies": {
         "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@types/node": "^24.0.0",

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -30,6 +30,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
   "devDependencies": {
     "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@types/node": "^24.0.0",

--- a/runners/sdk/tsup.config.ts
+++ b/runners/sdk/tsup.config.ts
@@ -13,4 +13,13 @@ export default defineConfig({
   target: "node20",
   external: ["node:*"],
   sourcemap: true,
+  // ESM output bundling CJS deps (yaml, etc.) that call require() at runtime needs a
+  // real require — without this shim esbuild's stub throws "Dynamic require ... not supported".
+  // Mirrors the createRequire banner in the cli/mcp esbuild bundles.
+  banner: {
+    js: [
+      "import { createRequire } from 'module';",
+      "const require = createRequire(import.meta.url);",
+    ].join("\n"),
+  },
 });


### PR DESCRIPTION
## Problem

`@keyvaluesystems/agent-opfor-sdk` was unpublishable in its current state for three reasons:

1. `@modelcontextprotocol/sdk` was used at runtime but not declared as a dependency — consumers would get "Cannot find module" on install.
2. The ESM bundle inlines CJS packages (e.g. `yaml`) that call `require()` at runtime. Without a `createRequire` shim in the banner, esbuild's stub throws "Dynamic require of … is not supported".
3. When `core/atlas.ts` is bundled into a runner, tsup flattens the file to `<pkg>/dist/*.js`, moving `atlas-data/` one level closer. The resolver only checked 2 levels up (correct for the standalone core package) and 3 levels up (monorepo dev), missing the bundled-runner layout — causing ATLAS.yaml to not be found at runtime.

## Solution

- **`runners/sdk/package.json`** — added `@modelcontextprotocol/sdk: ^1.29.0` to `dependencies`. tsup leaves these as bare imports in the output; the SDK must be present in the consumer's `node_modules`.
- **`runners/sdk/tsup.config.ts`** — added a `banner.js` injecting `createRequire(import.meta.url)` into the ESM output. Mirrors the identical fix already in the cli and mcp esbuild bundles.
- **`core/src/standards/atlas.ts`** — extended `atlasYamlPath()` to try three candidates in order: `here/../atlas-data/` (bundled runner, new), `here/../../atlas-data/` (published core package), `here/../../../third_party/atlas-data/dist/` (monorepo dev). Falls back to the last candidate if none exist.

Verified with `npm run build` (clean), `npm pack --dry-run` (atlas-data ships at package root), and a runtime `import()` smoke test (all six public exports resolve without errors).


## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [ ] `npm run build:catalog:check` passes _(if evaluators or suites changed)_
- [ ] Tested against a local target _(if evaluator added or changed)_
- [x] No secrets, `.env`, or `.opfor/` artifacts committed
- [x] PR title follows `<type>: <what changed>` — e.g. `feat: add SSRF evaluator`

## Evaluator checklist _(skip if no evaluator added)_

- [ ] `id` is unique across all evaluators
- [ ] `pass_criteria` and `fail_criteria` are specific, not vague
- [ ] `severity` matches actual risk (`critical` = RCE / data breach)
- [ ] `standards` mapping is correct
- [ ] `.test.yaml` fixture included


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for additional ATLAS YAML layout locations, making path lookup more reliable across bundled runner setups.
  * Enhanced bundled SDK compatibility so packages that use CommonJS-style loading work correctly in ESM builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->