### PR TITLE
chore: update npm metadata for packages to be released

### DIFF
--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -24,6 +24,28 @@
     "prepack": "rm -rf ./evaluators ./suites ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./atlas-data ./LICENSE"
   },
+  "homepage": "https://agentopfor.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KeyValueSoftwareSystems/agent-opfor.git",
+    "directory": "runners/cli"
+  },
+  "bugs": {
+    "url": "https://github.com/KeyValueSoftwareSystems/agent-opfor/issues"
+  },
+  "author": "KeyValue Software Systems",
+  "keywords": [
+    "ai-security",
+    "red-team",
+    "llm",
+    "mcp",
+    "owasp",
+    "prompt-injection",
+    "agent-security"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -23,6 +23,28 @@
     "prepack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
   },
+  "homepage": "https://agentopfor.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KeyValueSoftwareSystems/agent-opfor.git",
+    "directory": "runners/mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/KeyValueSoftwareSystems/agent-opfor/issues"
+  },
+  "author": "KeyValue Software Systems",
+  "keywords": [
+    "ai-security",
+    "red-team",
+    "llm",
+    "mcp",
+    "owasp",
+    "prompt-injection",
+    "agent-security"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/runners/sdk/package.json
+++ b/runners/sdk/package.json
@@ -27,6 +27,28 @@
     "prepack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE && cp -r ../../evaluators ./evaluators && cp -r ../../suites ./suites && cp -r ../cli/data ./data && mkdir -p ./atlas-data && cp ../../third_party/atlas-data/dist/ATLAS.yaml ./atlas-data/ATLAS.yaml && cp ../../LICENSE ./LICENSE",
     "postpack": "rm -rf ./evaluators ./suites ./data ./atlas-data ./LICENSE"
   },
+  "homepage": "https://agentopfor.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KeyValueSoftwareSystems/agent-opfor.git",
+    "directory": "runners/sdk"
+  },
+  "bugs": {
+    "url": "https://github.com/KeyValueSoftwareSystems/agent-opfor/issues"
+  },
+  "author": "KeyValue Software Systems",
+  "keywords": [
+    "ai-security",
+    "red-team",
+    "llm",
+    "mcp",
+    "owasp",
+    "prompt-injection",
+    "agent-security"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Problem

The package.json metadata was not present for the packages that were going to be released

## Solution

Add metadata and engine field foo node in package.json of three packages

<!-- Required: explain what this PR does and the motivation behind it. -->

## Checklist

- [x] `npm run build` passes
- [x] `npm run typecheck` passes
- [x] `npm run build:catalog:check` passes _(if evaluators or suites changed)_
- [ ] Tested against a local target _(if evaluator added or changed)_
- [x] No secrets, `.env`, or `.opfor/` artifacts committed
- [x] PR title follows `<type>: <what changed>` — e.g. `feat: add SSRF evaluator`

## Evaluator checklist _(skip if no evaluator added)_

- [ ] `id` is unique across all evaluators
- [ ] `pass_criteria` and `fail_criteria` are specific, not vague
- [ ] `severity` matches actual risk (`critical` = RCE / data breach)
- [ ] `standards` mapping is correct
- [ ] `.test.yaml` fixture included
