### PR TITLE
test: suppress AI SDK warnings and simplify PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
         - CLI (`opfor run` / `opfor setup`)
         - CLI — Autonomous mode (`opfor hunt`)
         - MCP Server (`@keyvaluesystems/agent-opfor-mcp`)
-        - Browser Extension
+        - Browser Extension (`@keyvaluesystems/agent-opfor-extension`)
         - SDK (`@keyvaluesystems/agent-opfor-sdk`)
         - Evaluators / Suites
         - Judge (LLM-as-judge)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,26 +1,23 @@
 ## Problem
 
-Briefly describe the issue or feature being addressed.
+<!-- What was broken or missing? -->
 
 ## Solution
 
-Explain your approach and any important design decisions.
+<!-- How does this PR fix it? -->
 
-<!-- Required: explain what this PR does and the motivation behind it. -->
+## Changes
 
-## Checklist
+<!-- Packages and files affected -->
 
-- [ ] `npm run build` passes
-- [ ] `npm run typecheck` passes
-- [ ] `npm run build:catalog:check` passes _(if evaluators or suites changed)_
-- [ ] Tested against a local target _(if evaluator added or changed)_
-- [ ] No secrets, `.env`, or `.opfor/` artifacts committed
-- [ ] PR title follows `<type>: <what changed>` — e.g. `feat: add SSRF evaluator`
+## Issue
 
-## Evaluator checklist _(skip if no evaluator added)_
+<!-- Closes #123 / N/A -->
 
-- [ ] `id` is unique across all evaluators
-- [ ] `pass_criteria` and `fail_criteria` are specific, not vague
-- [ ] `severity` matches actual risk (`critical` = RCE / data breach)
-- [ ] `standards` mapping is correct
-- [ ] `.test.yaml` fixture included
+## How to test
+
+<!-- Steps for the maintainer to verify this works -->
+
+## Screenshots
+
+<!-- If applicable — report HTML, extension UI, CLI output -->

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -2,7 +2,7 @@ name: Commit Lint
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, main]
 
 jobs:
   branch-name:
@@ -41,7 +41,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/core/tests/evaluators.judge.test.ts
+++ b/core/tests/evaluators.judge.test.ts
@@ -1,3 +1,5 @@
+(globalThis as Record<string, unknown>).AI_SDK_LOG_WARNINGS = false;
+
 /**
  * Evaluator judge smoke tests.
  *

--- a/package-lock.json
+++ b/package-lock.json
@@ -5752,6 +5752,9 @@
         "esbuild": "^0.25.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "runners/cli/node_modules/@esbuild/aix-ppc64": {
@@ -6758,6 +6761,9 @@
         "esbuild": "^0.25.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "runners/mcp/node_modules/@esbuild/aix-ppc64": {
@@ -7257,6 +7263,9 @@
         "tsup": "^8.0.0",
         "tsx": "^4.20.0",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
         "typescript": ">=5.0.0"


### PR DESCRIPTION
## Problem

Judge smoke test CI printed noisy AI SDK spec compatibility warnings on every run. PR template had verbose checklists CI already enforces.

## Solution

Set `AI_SDK_LOG_WARNINGS = false` in the test file (mirrors the CLI entrypoint). Replaced PR template checklists with minimal narrative sections.

## Changes

- `core/tests/evaluators.judge.test.ts`
- `.github/pull_request_template.md`

## Issue

N/A

## How to test

    GROQ_API_KEY=... node --import tsx/esm --test core/tests/evaluators.judge.test.ts

Confirm no `AI SDK Warning` lines in output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the pull request template with clearer sections for problem, solution, changes, testing, and screenshots.
* **Bug Fixes**
  * Refined the bug report form so the browser extension option is labeled more clearly.
* **Chores**
  * Updated automated PR checks to run on both main branch names and refreshed the Node.js version used by the validation workflow.
  * Reduced noisy warning output during test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->