### PR TITLE
test: align send-budget default assertion with shipped 20x/200 cap

### DIFF
--- a/runners/cli/tests/fork.test.ts
+++ b/runners/cli/tests/fork.test.ts
@@ -117,9 +117,9 @@ test("sendAllowed caps total sends and refuses NEW threads past the tree ceiling
   assert.equal(budget.sendAllowed(false, 1).ok, false, "all sends refused past the send budget");
 });
 
-test("maxTotalSends defaults to ~50× budgetUsd when unset", () => {
-  assert.equal(new BudgetGuard({ maxThreadTurns: 25, budgetUsd: 6 }).maxTotalSends, 300);
-  assert.equal(new BudgetGuard({ maxThreadTurns: 25 }).maxTotalSends, 400, "no budget → 400");
+test("maxTotalSends defaults to ~20× budgetUsd when unset", () => {
+  assert.equal(new BudgetGuard({ maxThreadTurns: 25, budgetUsd: 6 }).maxTotalSends, 120);
+  assert.equal(new BudgetGuard({ maxThreadTurns: 25 }).maxTotalSends, 200, "no budget → 200");
 });
 
 function finding(threadId: string, evidence: string, confidence: number): Finding {


### PR DESCRIPTION
## Problem
`runners/cli/tests/fork.test.ts` fails on `master`, so the CLI test suite is red (28/29). CI does not surface this because the `test` job runs only the `core` and `sdk` workspaces — the CLI suite is never executed.

## Root cause
The test asserted `BudgetGuard` send-budget defaults of **300** (`50× budgetUsd`) and **400** (no budget), but the shipped code in `core/src/autonomous/lib/budget.ts:64` uses **`20× budgetUsd`** (else **200**):

```ts
this.maxTotalSends =
  opts.maxTotalSends ?? (opts.budgetUsd ? Math.ceil(opts.budgetUsd * 20) : 200);
```

So `budgetUsd: 6 → 120` (not 300) and no-budget `→ 200` (not 400).

## Change
Test-only. Assertions + test name updated to match the shipped 20×/200 behaviour (the lower, intended spend ceiling). No production code touched.

## How verified
- `npm test --workspace=@keyvaluesystems/agent-opfor-cli` → green (was failing)
- `npm run typecheck` · `npm run lint` · `npm run format:check` → pass
- Committed with the full pre-commit hook (typecheck/lint/format/catalog/validate-skills/gitleaks), no `--no-verify`.

## Follow-ups (separate PRs)
- Run the CLI + MCP workspaces in CI so this class of regression is caught.