### PR TITLE
chore: add gitleaks secret-scan workflow and fix .env.example provider vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,10 +17,10 @@
 # Google Gemini
 # GOOGLE_GENERATIVE_AI_API_KEY=
 
-# ── OpenAI-compatible endpoints (provider: "other") ───────────────────────────
-# Set a base URL in your opfor config instead of here. API key goes below
-# if the endpoint requires one.
-# CUSTOM_LLM_API_KEY=
+# ── OpenAI-compatible endpoints (provider: "openai-compatible") ───────────────
+# LiteLLM, OpenRouter, Azure, Ollama, etc. Set the base URL in your opfor config;
+# put the API key here if the endpoint requires one.
+# OPFOR_API_KEY=
 
 # ── Telemetry enrichment (optional) ──────────────────────────────────────────
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,19 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What
- Adds a `Secret Scan` GitHub Actions workflow running `gitleaks/gitleaks-action@v2` on pushes/PRs to master (uses the existing tuned `.gitleaks.toml`).
- Fixes `.env.example`: the OpenAI-compatible section referenced `provider: "other"` and `CUSTOM_LLM_API_KEY`, but the code (`core/src/providers/factory.ts`) uses provider id `openai-compatible` and env var `OPFOR_API_KEY`.

## Why
A tuned `.gitleaks.toml` existed but no workflow ran it — nothing scanned PRs for committed secrets. The `.env.example` drift is a first-run papercut that sends new users to the wrong variable.

## Verified
`npm run typecheck`, `npm run lint`, `npm run format:check` all pass; committed with the full pre-commit hook (incl. gitleaks, 0 leaks), no `--no-verify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the example environment configuration to reflect the current OpenAI-compatible setup and revised the suggested API key placeholder.
* **Chores**
  * Added an automated secret-scanning check to help catch sensitive information in pull requests and pushes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->