### PR TITLE
chore: reconcile package metadata and declare only un-bundlable runner deps

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -6,6 +6,9 @@
   "private": true,
   "type": "module",
   "main": "./dist/index.js",
+  "engines": {
+    "node": ">=20"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -96,7 +99,6 @@
     "@ai-sdk/openai-compatible": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.0",
-    "consola": "^3.4.2",
     "yaml": "^2.8.3",
     "zod": "^3.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1407,6 +1407,7 @@
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1414,6 +1415,7 @@
     },
     "node_modules/@inquirer/checkbox": {
       "version": "5.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
@@ -1435,6 +1437,7 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "6.0.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1454,6 +1457,7 @@
     },
     "node_modules/@inquirer/core": {
       "version": "11.1.9",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
@@ -1478,6 +1482,7 @@
     },
     "node_modules/@inquirer/editor": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1498,6 +1503,7 @@
     },
     "node_modules/@inquirer/expand": {
       "version": "5.0.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1517,6 +1523,7 @@
     },
     "node_modules/@inquirer/external-editor": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chardet": "^2.1.1",
@@ -1536,6 +1543,7 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1543,6 +1551,7 @@
     },
     "node_modules/@inquirer/input": {
       "version": "5.0.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1562,6 +1571,7 @@
     },
     "node_modules/@inquirer/number": {
       "version": "4.0.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1581,6 +1591,7 @@
     },
     "node_modules/@inquirer/password": {
       "version": "5.0.12",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
@@ -1601,6 +1612,7 @@
     },
     "node_modules/@inquirer/prompts": {
       "version": "8.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/checkbox": "^5.1.4",
@@ -1628,6 +1640,7 @@
     },
     "node_modules/@inquirer/rawlist": {
       "version": "5.2.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1647,6 +1660,7 @@
     },
     "node_modules/@inquirer/search": {
       "version": "4.1.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^11.1.9",
@@ -1667,6 +1681,7 @@
     },
     "node_modules/@inquirer/select": {
       "version": "5.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^2.0.5",
@@ -1688,6 +1703,7 @@
     },
     "node_modules/@inquirer/type": {
       "version": "4.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -2272,7 +2288,7 @@
       "version": "24.12.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2832,6 +2848,7 @@
     },
     "node_modules/chardet": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/chokidar": {
@@ -2885,6 +2902,7 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -2932,6 +2950,7 @@
     },
     "node_modules/commander": {
       "version": "14.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -2957,6 +2976,7 @@
     },
     "node_modules/consola": {
       "version": "3.4.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -3153,6 +3173,7 @@
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3634,10 +3655,12 @@
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
@@ -3661,6 +3684,7 @@
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -4521,6 +4545,7 @@
     },
     "node_modules/mute-stream": {
       "version": "3.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -5164,6 +5189,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -5533,7 +5559,7 @@
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -5726,34 +5752,34 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.165",
+        "@modelcontextprotocol/sdk": "^1.29.0"
+      },
+      "bin": {
+        "opfor": "dist/index.js"
+      },
+      "devDependencies": {
         "@ai-sdk/anthropic": "^2.0.77",
         "@ai-sdk/azure": "^3.0.65",
         "@ai-sdk/deepseek": "^2.0.35",
         "@ai-sdk/google": "^2.0.70",
         "@ai-sdk/openai": "^2.0.103",
         "@ai-sdk/openai-compatible": "^1.0.0",
-        "@anthropic-ai/claude-agent-sdk": "^0.3.165",
         "@anthropic-ai/sdk": "^0.100.1",
         "@inquirer/prompts": "^8.4.2",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
+        "@types/express": "^5.0.3",
+        "@types/node": "^24.0.0",
         "ai": "^6.0.0",
         "commander": "^14.0.1",
         "consola": "^3.4.2",
         "dotenv": "^17.4.2",
+        "esbuild": "^0.25.0",
         "express": "^5.1.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.8.3",
         "yaml": "^2.8.3",
         "zod": "^3.0.0"
-      },
-      "bin": {
-        "opfor": "dist/index.js"
-      },
-      "devDependencies": {
-        "@keyvaluesystems/agent-opfor-core": "^0.9.0",
-        "@types/express": "^5.0.3",
-        "@types/node": "^24.0.0",
-        "esbuild": "^0.25.0",
-        "tsx": "^4.20.0",
-        "typescript": "^5.8.3"
       },
       "engines": {
         "node": ">=20"
@@ -6743,17 +6769,7 @@
       "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ai-sdk/anthropic": "^2.0.77",
-        "@ai-sdk/azure": "^3.0.65",
-        "@ai-sdk/deepseek": "^2.0.35",
-        "@ai-sdk/google": "^2.0.70",
-        "@ai-sdk/openai": "^2.0.103",
-        "@ai-sdk/openai-compatible": "^1.0.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "ai": "^6.0.0",
-        "dotenv": "^17.4.2",
-        "yaml": "^2.8.3",
-        "zod": "^3.0.0"
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {
         "opfor-agent-mcp": "dist/index.js"
@@ -6761,9 +6777,11 @@
       "devDependencies": {
         "@keyvaluesystems/agent-opfor-core": "^0.9.0",
         "@types/node": "^24.0.0",
+        "dotenv": "^17.4.2",
         "esbuild": "^0.25.0",
         "tsx": "^4.20.0",
-        "typescript": "^5.8.3"
+        "typescript": "^5.8.3",
+        "zod": "^3.0.0"
       },
       "engines": {
         "node": ">=20"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "zod": "^3.25.76"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20"
       }
     },
     "core": {
@@ -47,7 +47,6 @@
         "@ai-sdk/openai-compatible": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
-        "consola": "^3.4.2",
         "yaml": "^2.8.3",
         "zod": "^3.0.0"
       },
@@ -56,6 +55,9 @@
         "@anthropic-ai/sdk": "^0.100.1",
         "@types/node": "^24.0.0",
         "typescript": "^5.8.3"
+      },
+      "engines": {
+        "node": ">=20"
       },
       "peerDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.3.165",
@@ -6742,12 +6744,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^2.0.77",
+        "@ai-sdk/azure": "^3.0.65",
+        "@ai-sdk/deepseek": "^2.0.35",
         "@ai-sdk/google": "^2.0.70",
         "@ai-sdk/openai": "^2.0.103",
         "@ai-sdk/openai-compatible": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ai": "^6.0.0",
-        "consola": "^3.4.2",
         "dotenv": "^17.4.2",
         "yaml": "^2.8.3",
         "zod": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "LICENSE"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20"
   },
   "scripts": {
     "build": "npm run build:catalog && tsc -b core && npm run build -w runners/cli && npm run build -w runners/mcp && npm run build -w runners/sdk && npm run extension:catalog && npm run build:core --workspace=@keyvaluesystems/agent-opfor-extension",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,11 @@
         "runners/mcp/package.json",
         "runners/sdk/package.json",
         "runners/extension/package.json",
+        {
+          "type": "json",
+          "path": "runners/extension/manifest.json",
+          "jsonpath": "$.version"
+        },
         "tests/e2e/agents/vanilla-chat/package.json",
         "tests/e2e/agents/customer-support/package.json",
         "tests/e2e/agents/vulnerable-memory/package.json",

--- a/runners/cli/package.json
+++ b/runners/cli/package.json
@@ -51,29 +51,29 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.3.165",
-    "@anthropic-ai/sdk": "^0.100.1",
+    "@modelcontextprotocol/sdk": "^1.29.0"
+  },
+  "devDependencies": {
     "@ai-sdk/anthropic": "^2.0.77",
     "@ai-sdk/azure": "^3.0.65",
     "@ai-sdk/deepseek": "^2.0.35",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",
     "@ai-sdk/openai-compatible": "^1.0.0",
+    "@anthropic-ai/sdk": "^0.100.1",
     "@inquirer/prompts": "^8.4.2",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.0.0",
     "ai": "^6.0.0",
     "commander": "^14.0.1",
     "consola": "^3.4.2",
     "dotenv": "^17.4.2",
+    "esbuild": "^0.25.0",
     "express": "^5.1.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.8.3",
     "yaml": "^2.8.3",
     "zod": "^3.0.0"
-  },
-  "devDependencies": {
-    "@keyvaluesystems/agent-opfor-core": "^0.9.0",
-    "@types/express": "^5.0.3",
-    "@types/node": "^24.0.0",
-    "esbuild": "^0.25.0",
-    "tsx": "^4.20.0",
-    "typescript": "^5.8.3"
   }
 }

--- a/runners/extension/manifest.json
+++ b/runners/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent OPFOR",
-  "version": "0.0.2",
+  "version": "0.9.0",
   "description": "Red-team any chat interface. Auto-detects chat widgets, runs adaptive attacks, and generates security reports.",
   "icons": {
     "16": "icons/icon16.png",

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -50,12 +50,13 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.77",
+    "@ai-sdk/azure": "^3.0.65",
+    "@ai-sdk/deepseek": "^2.0.35",
     "@ai-sdk/google": "^2.0.70",
     "@ai-sdk/openai": "^2.0.103",
     "@ai-sdk/openai-compatible": "^1.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ai": "^6.0.0",
-    "consola": "^3.4.2",
     "dotenv": "^17.4.2",
     "yaml": "^2.8.3",
     "zod": "^3.0.0"

--- a/runners/mcp/package.json
+++ b/runners/mcp/package.json
@@ -49,23 +49,15 @@
     "access": "public"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^2.0.77",
-    "@ai-sdk/azure": "^3.0.65",
-    "@ai-sdk/deepseek": "^2.0.35",
-    "@ai-sdk/google": "^2.0.70",
-    "@ai-sdk/openai": "^2.0.103",
-    "@ai-sdk/openai-compatible": "^1.0.0",
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "ai": "^6.0.0",
-    "dotenv": "^17.4.2",
-    "yaml": "^2.8.3",
-    "zod": "^3.0.0"
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@keyvaluesystems/agent-opfor-core": "^0.9.0",
     "@types/node": "^24.0.0",
+    "dotenv": "^17.4.2",
     "esbuild": "^0.25.0",
     "tsx": "^4.20.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod": "^3.0.0"
   }
 }


### PR DESCRIPTION
## What

Pre-release package-metadata hygiene across the workspace, in two parts.

### 1. Metadata reconciliation
- **Node engines** reconciled to `>=20` (root was `>=18.0.0` while all runners already require `>=20`; CI runs Node 22). Added an explicit `engines` field to `core`.
- **Removed the unused `consola` dependency** from `core` and `mcp` — it's only imported by the CLI (verified via grep).
- **Browser extension**: bumped `manifest.json` version `0.0.2 → 0.9.0` to match the package version.

### 2. Runner dependencies: declare only what can't be bundled
The `cli`, `mcp`, and `sdk` runners each ship a **self-contained bundle** (esbuild/tsup with only `node:*` external), so every third-party library is inlined into `dist/`. Declaring those inlined libraries as runtime `dependencies` made consumers `npm install` packages they never load at runtime.

Rule applied (matches how bundled packages like Prettier, `@vercel/ncc`, and Wrangler declare deps): **keep in `dependencies` only what the bundle genuinely cannot inline** and resolves from `node_modules` at runtime; move everything inlined to `devDependencies`.

Verified against the actual build output — the only un-inlinable runtime references are:
- `ajv` / `ajv-formats` — the MCP SDK's validators `require()` these by path at runtime; no bundler can inline them. Provided transitively by `@modelcontextprotocol/sdk`.
- `@anthropic-ai/claude-agent-sdk` (cli only) — spawns a **native platform binary** shipped via its `optionalDependencies` (8 platform variants); resolved from `node_modules` at runtime.
- `supports-color` (cli) — required inside a `try {}` (the `debug` library's optional color probe), so its absence is handled gracefully — left undeclared.

| Package | `dependencies` before → after | Kept because |
| --- | --- | --- |
| **sdk** | `@modelcontextprotocol/sdk` → **unchanged** | already correct |
| **mcp** | 10 libs → **1** (`@modelcontextprotocol/sdk`) | brings `ajv`/`ajv-formats` |
| **cli** | 17 libs → **2** (`@anthropic-ai/claude-agent-sdk`, `@modelcontextprotocol/sdk`) | native binary + `ajv` |

Everything else (`@ai-sdk/*`, `ai`, `@anthropic-ai/sdk`, `express`, `commander`, `@inquirer/prompts`, `dotenv`, `yaml`, `zod`) moved to `devDependencies` (or dropped where already transitive via `core`).

> This supersedes the earlier revision of this PR, which added `@ai-sdk/azure` and `@ai-sdk/deepseek` to `mcp` `dependencies` — under the bundle-hygiene rule those don't belong there at all.

## Why
Pre-release metadata consistency: an accurate engine floor, no phantom dependencies, a coherent extension version, and published packages that install only the code they actually load at runtime instead of dragging in the entire (already-bundled) dependency tree.

## Verified
- `npm run typecheck`, `npm run lint`, `npm run format:check` pass (full pre-commit hook incl. gitleaks, no `--no-verify`).
- Builds pass: `core`, `mcp`, `sdk`, and the `cli` esbuild bundle.
- Runtime resolution confirmed: `ajv`/`ajv-formats` reach all three runners via the MCP SDK; `@anthropic-ai/claude-agent-sdk` + its `linux-x64` native binary resolve for `cli`.
- `sdk` bundle imports clean in Node (no `MODULE_NOT_FOUND`); `mcp` server binary boots without crashing.
- Lockfile synced via `npm install --package-lock-only` (no package downloads).

## Note for reviewers
The `cli` change preserves `@anthropic-ai/claude-agent-sdk` exactly as it ships today (still a runtime `dependency`, still bundled the same way), so there is no behavioral change to `opfor hunt`. A clean-install `opfor hunt` smoke test is nonetheless the recommended final gate before release, since that's the path that spawns the native binary.
