### PR TITLE
fix: broken gitleaks ci for fork

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,10 +1,13 @@
 name: Secret Scan
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [master, main]
   push:
     branches: [master, main]
+
+permissions:
+  contents: read
 
 jobs:
   gitleaks:
@@ -13,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Problem

Fork PRs failed the `Secret Scan` check — `pull_request` events don't get repo/org secrets when the PR comes from a fork, so `GITLEAKS_LICENSE` was empty and gitleaks errored out.

## Solution

Switch the workflow to `pull_request_target` so it runs with base-repo secrets, while explicitly checking out the PR's head SHA (since `pull_request_target` defaults to the base branch) and scoping `GITHUB_TOKEN` to read-only.

## Changes

- `.github/workflows/secret-scan.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated security checks on incoming changes.
  * Tightened workflow access to use only the minimum needed permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->