### PR TITLE
feat: stream run lifecycle events as ndjson via a run-listener

### DIFF
--- a/runners/cli/src/commands/run.ts
+++ b/runners/cli/src/commands/run.ts
@@ -10,6 +10,8 @@ import { normalizeEffort } from "@keyvaluesystems/agent-opfor-core/execute/effor
 import { runSetupAndWrite } from "./setup.js";
 import { ensureOpforDirs, OPFOR_DIR, OPFOR_REPORTS_DIR } from "../lib/artifacts.js";
 import { ConsoleProgressListener } from "../lib/consoleProgressListener.js";
+import { JsonlEventListener } from "../lib/jsonlEventListener.js";
+import type { RunListener } from "@keyvaluesystems/agent-opfor-core/execute/runListener.js";
 
 export function registerRunCommand(program: Command): void {
   program
@@ -22,6 +24,10 @@ export function registerRunCommand(program: Command): void {
     .option("--turns <n>", "Override turns per attack (1 = single turn)")
     .option("--output <dir>", "Directory for HTML + JSON reports (default: .opfor/reports/)")
     .option("--env <path>", "Path to .env file to load")
+    .option(
+      "--events <path>",
+      "Stream run lifecycle events as newline-delimited JSON (NDJSON) to <path>"
+    )
     .action(
       async (opts: {
         config?: string;
@@ -29,6 +35,7 @@ export function registerRunCommand(program: Command): void {
         turns?: string;
         output?: string;
         env?: string;
+        events?: string;
       }) => {
         if (opts.env) {
           const { config: loadDotenv } = await import("dotenv");
@@ -95,9 +102,25 @@ export function registerRunCommand(program: Command): void {
         log.info("");
 
         await ensureOpforDirs();
+        // Terminal progress always; NDJSON event stream only when --events is set.
+        // A new output format is just a new listener — no engine change.
+        const listeners: RunListener[] = [new ConsoleProgressListener()];
+        if (opts.events) {
+          const eventsPath = path.resolve(opts.events);
+          try {
+            // Fail fast, before the assessment runs, if the path isn't writable.
+            listeners.push(new JsonlEventListener(eventsPath));
+          } catch (err) {
+            log.error(
+              `Cannot open --events file ${eventsPath}: ${err instanceof Error ? err.message : String(err)}`
+            );
+            process.exitCode = 1;
+            return;
+          }
+        }
         const report = await runAll(runConfig, {
           outputDir: path.resolve(OPFOR_DIR),
-          listeners: [new ConsoleProgressListener()],
+          listeners,
         });
 
         log.info("\n\nWriting report...");

--- a/runners/cli/src/lib/jsonlEventListener.ts
+++ b/runners/cli/src/lib/jsonlEventListener.ts
@@ -1,0 +1,63 @@
+import { writeFileSync, appendFileSync } from "node:fs";
+import type { RunListener } from "@keyvaluesystems/agent-opfor-core/execute/runListener.js";
+import type { UnifiedRunReport } from "@keyvaluesystems/agent-opfor-core/execute/types.js";
+
+/**
+ * Streams run lifecycle events as newline-delimited JSON (one event per line) to a
+ * file — a machine-readable alternative output for CI / automation that can tail
+ * progress and results live.
+ *
+ * This is the RunListener SPI's payoff: a new output format is just a new listener,
+ * with zero engine changes. Writes are synchronous so events land in order and a
+ * hook can never race the run (notifyListeners isolates any throw).
+ */
+export class JsonlEventListener implements RunListener {
+  constructor(private readonly path: string) {
+    // Start each run with a fresh file so a re-run doesn't append to stale events.
+    writeFileSync(this.path, "");
+  }
+
+  private write(event: Record<string, unknown>): void {
+    appendFileSync(this.path, JSON.stringify({ ts: new Date().toISOString(), ...event }) + "\n");
+  }
+
+  onRunStart(info: { evaluatorCount: number }): void {
+    this.write({ type: "run_start", evaluatorCount: info.evaluatorCount });
+  }
+
+  onEvaluatorStart(info: { evaluatorId: string; evaluatorName: string }): void {
+    this.write({ type: "evaluator_start", ...info });
+  }
+
+  onAttackStart(info: { attackId: string; patternName: string }): void {
+    this.write({ type: "attack_start", ...info });
+  }
+
+  onAttackDone(info: { attackId: string; verdict: "PASS" | "FAIL" | "ERROR" }): void {
+    this.write({ type: "attack_done", ...info });
+  }
+
+  onEvaluatorDone(info: {
+    evaluatorId: string;
+    passed: number;
+    failed: number;
+    errors: number;
+  }): void {
+    this.write({ type: "evaluator_done", ...info });
+  }
+
+  onRunStopped(info: { reason: string }): void {
+    this.write({ type: "run_stopped", reason: info.reason });
+  }
+
+  onRunError(info: { error: unknown }): void {
+    this.write({
+      type: "run_error",
+      error: info.error instanceof Error ? info.error.message : String(info.error),
+    });
+  }
+
+  onRunFinish(report: UnifiedRunReport): void {
+    this.write({ type: "run_finish", reportId: report.reportId, summary: report.summary });
+  }
+}

--- a/runners/cli/tests/jsonlEventListener.test.ts
+++ b/runners/cli/tests/jsonlEventListener.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { JsonlEventListener } from "../src/lib/jsonlEventListener.js";
+import type { UnifiedRunReport } from "@keyvaluesystems/agent-opfor-core/execute/types.js";
 
 async function tmpFile() {
   const dir = await mkdtemp(path.join(tmpdir(), "opfor-events-"));
@@ -24,23 +25,51 @@ test("writes one NDJSON line per lifecycle event with type + payload", async () 
     const l = new JsonlEventListener(file);
     l.onRunStart({ evaluatorCount: 2 });
     l.onEvaluatorStart({ evaluatorId: "e1", evaluatorName: "Eval One" });
+    l.onAttackStart({ attackId: "a1", patternName: "Pattern One" });
     l.onAttackDone({ attackId: "a1", verdict: "FAIL" });
     l.onEvaluatorDone({ evaluatorId: "e1", passed: 1, failed: 2, errors: 0 });
+    l.onRunStopped({ reason: "budget exhausted" });
     l.onRunError({ error: new Error("boom") });
-    l.onRunFinish({
+    const report: UnifiedRunReport = {
       reportId: "r1",
-      summary: { total: 3, passed: 1, failed: 2, errors: 0, safetyScore: 33 },
-    } as never);
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      targetName: "target",
+      targetKind: "agent",
+      effort: "adaptive",
+      attackModel: "attacker-model",
+      judgeModel: "judge-model",
+      summary: {
+        total: 3,
+        passed: 1,
+        failed: 2,
+        errors: 0,
+        safetyScore: 33,
+        attackSuccessRate: 67,
+      },
+      evaluators: [],
+    };
+    l.onRunFinish(report);
 
     const lines = await readLines(file);
     assert.deepStrictEqual(
       lines.map((e) => e.type),
-      ["run_start", "evaluator_start", "attack_done", "evaluator_done", "run_error", "run_finish"]
+      [
+        "run_start",
+        "evaluator_start",
+        "attack_start",
+        "attack_done",
+        "evaluator_done",
+        "run_stopped",
+        "run_error",
+        "run_finish",
+      ]
     );
     assert.strictEqual(lines[0].evaluatorCount, 2);
-    assert.strictEqual(lines[2].verdict, "FAIL");
-    assert.strictEqual(lines[4].error, "boom"); // Error unwrapped to its message
-    assert.deepStrictEqual((lines[5].summary as { failed: number }).failed, 2);
+    assert.strictEqual(lines[2].patternName, "Pattern One");
+    assert.strictEqual(lines[3].verdict, "FAIL");
+    assert.strictEqual(lines[5].reason, "budget exhausted");
+    assert.strictEqual(lines[6].error, "boom"); // Error unwrapped to its message
+    assert.deepStrictEqual((lines[7].summary as { failed: number }).failed, 2);
     // Every line carries a timestamp.
     assert.ok(lines.every((e) => typeof e.ts === "string"));
   } finally {

--- a/runners/cli/tests/jsonlEventListener.test.ts
+++ b/runners/cli/tests/jsonlEventListener.test.ts
@@ -1,0 +1,64 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { JsonlEventListener } from "../src/lib/jsonlEventListener.js";
+
+async function tmpFile() {
+  const dir = await mkdtemp(path.join(tmpdir(), "opfor-events-"));
+  return { dir, file: path.join(dir, "events.jsonl") };
+}
+
+async function readLines(file: string): Promise<Array<Record<string, unknown>>> {
+  const raw = await readFile(file, "utf8");
+  return raw
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as Record<string, unknown>);
+}
+
+test("writes one NDJSON line per lifecycle event with type + payload", async () => {
+  const { dir, file } = await tmpFile();
+  try {
+    const l = new JsonlEventListener(file);
+    l.onRunStart({ evaluatorCount: 2 });
+    l.onEvaluatorStart({ evaluatorId: "e1", evaluatorName: "Eval One" });
+    l.onAttackDone({ attackId: "a1", verdict: "FAIL" });
+    l.onEvaluatorDone({ evaluatorId: "e1", passed: 1, failed: 2, errors: 0 });
+    l.onRunError({ error: new Error("boom") });
+    l.onRunFinish({
+      reportId: "r1",
+      summary: { total: 3, passed: 1, failed: 2, errors: 0, safetyScore: 33 },
+    } as never);
+
+    const lines = await readLines(file);
+    assert.deepStrictEqual(
+      lines.map((e) => e.type),
+      ["run_start", "evaluator_start", "attack_done", "evaluator_done", "run_error", "run_finish"]
+    );
+    assert.strictEqual(lines[0].evaluatorCount, 2);
+    assert.strictEqual(lines[2].verdict, "FAIL");
+    assert.strictEqual(lines[4].error, "boom"); // Error unwrapped to its message
+    assert.deepStrictEqual((lines[5].summary as { failed: number }).failed, 2);
+    // Every line carries a timestamp.
+    assert.ok(lines.every((e) => typeof e.ts === "string"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("truncates a stale file on construction (fresh per run)", async () => {
+  const { dir, file } = await tmpFile();
+  try {
+    await writeFile(file, '{"type":"stale"}\n');
+    const l = new JsonlEventListener(file);
+    l.onRunStart({ evaluatorCount: 0 });
+
+    const lines = await readLines(file);
+    assert.strictEqual(lines.length, 1, "stale content is discarded");
+    assert.strictEqual(lines[0].type, "run_start");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What & why

The **payoff of the RunListener SPI** (#156): a new output format is just a new
listener — **zero engine changes**. This adds an opt-in, machine-readable
**NDJSON run-event stream** for CI / automation.

- **`jsonlEventListener.ts`** (new) — `JsonlEventListener implements RunListener`:
  one JSON line per lifecycle event (`run_start` → `evaluator_start` /
  `attack_start` / `attack_done` → `evaluator_done` / `run_stopped` / `run_error` /
  `run_finish`), each with an ISO `ts`; `onRunFinish` records `reportId` + `summary`.
- **`run.ts`** — new `--events <path>` flag adds the listener alongside
  `ConsoleProgressListener`.

```
opfor run --config c.json --events run.jsonl
# CI can `tail -f run.jsonl` for live progress; the final line is run_finish + summary
```

## Design notes (from review)

- **Synchronous writes** (`appendFileSync`) are deliberate: events land in order
  and **durably** — a CI tail sees them live and a crash can't lose buffered events.
  Cost is negligible next to LLM latency (the run is LLM-bound). A `WriteStream`
  would be marginally faster but could drop events on crash — wrong tradeoff for an
  event log.
- **Best-effort**: a write failure is isolated by `notifyListeners` (logged warning)
  so it can never abort the run or corrupt the HTML/JSON report.
- **Fail-fast**: a bad / unwritable `--events` path errors *before* the assessment
  runs, with an actionable message.
- The report and telemetry were intentionally **not** converted to listeners — the
  report's file paths are needed back synchronously, and the `TelemetryAdapter` is a
  trace *reader*, not a run-event sink.

## Backward compatibility

`--events` is additive; `onProgress`, the HTML/JSON report, and
`ConsoleProgressListener` are untouched.

## Verification

typecheck 0 · lint 0 · CLI tests 31/31 (2 new) · full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI option to export run lifecycle events to a JSONL file.
  * Events are written as one line per update, with timestamps and run summaries included.

* **Bug Fixes**
  * Output files now start fresh for each run, preventing stale event data from previous executions.

* **Tests**
  * Added coverage for event ordering, payload formatting, error handling, and file truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->