### PR TITLE
fix: revert gitleaks trigger from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,7 +1,7 @@
 name: Secret Scan
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [master, main]
   push:
     branches: [master, main]
@@ -16,7 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - uses: gitleaks/gitleaks-action@v2


### PR DESCRIPTION
## Problem

The secret scan CI job fails with:

```
ERROR: The [pull_request_target] event is not yet supported
```

`gitleaks/gitleaks-action@v2` only supports `push`, `pull_request`, `workflow_dispatch`, and `schedule`.

## Solution

Revert the workflow trigger to `pull_request` and remove the explicit checkout `ref` override.

## Changes

- `.github/workflows/secret-scan.yml`

## Issue

N/A

## How to test

1. Open a PR and confirm the gitleaks job runs successfully.
2. Push to `master` and confirm the secret scan still runs on push.

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated security-check handling for pull requests to use a safer default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->