### PR TITLE
refactor: single-touchpoint LLM provider registry across core, CLI, MCP, extension, and SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ See [Adding an evaluator](#adding-an-evaluator) for the full guide.
   - [PR naming](#pr-naming)
 - [**Adding an evaluator**](#adding-an-evaluator) ← most common contribution
 - [Adding a suite](#adding-a-suite)
+- [Adding an LLM provider](#adding-an-llm-provider)
 - [Adding a telemetry provider](#adding-a-telemetry-provider)
 - [Adding a test agent](#adding-a-test-agent)
 - [Submitting findings](#submitting-findings)
@@ -370,6 +371,33 @@ Opfor can fetch recorded traces from an observability platform and give them to 
    - Add a `myProvider?: MyProviderTelemetryConfig` block to `TelemetryConfig`.
 
 5. **Polling defaults** — `POLL_DEFAULTS` in `core/src/telemetry/pollingUtils.ts` gives you sensible starting values (`1000 ms` initial delay, `8` attempts, `1500 ms` between). Pass them through `fetchTraceForJudge`'s `opts` argument — callers can override per `TelemetryConfig`.
+
+---
+
+## Adding an LLM provider
+
+All provider metadata (default model, API key env var, capabilities, model builder) lives in one object: `providerRegistryData` in `core/src/providers/factory.ts`. CLI, MCP, and the browser extension all derive from it directly.
+
+### Checklist
+
+1. **Add an entry** to `providerRegistryData`:
+
+   ```typescript
+   "my-provider": {
+     displayName: "My Provider",
+     defaultModel: "my-provider-default-model",
+     envVar: "MY_PROVIDER_API_KEY",
+     capabilities: { supportsJsonMode: true, requiresBaseURL: false },
+     build: ({ apiKey, model }): LanguageModel => createMyProvider({ apiKey })(model),
+   },
+   ```
+
+   Set `requiresBaseURL: true` if the provider needs a user-supplied endpoint (e.g. Azure), and add `baseUrlPromptMessage` if the generic prompt copy isn't clear enough.
+
+2. **Add the env var row** to `AGENTS.md` and `.env.example`.
+3. **Add the SDK dependency** to `core/package.json` if the provider needs a new `@ai-sdk/*` package.
+4. **Extend `core/tests/providerFactory.test.ts`**'s `EXPECTED_PROVIDER_TAG` map with the new provider's SDK `.provider` tag (run the test once to see what the AI SDK reports).
+5. **Add the provider to `runners/sdk/src/types.ts`**'s `ProviderName` union. The SDK can't import core's types directly (core isn't published to npm), so this one hand-copied union is the exception — everything else derives from the registry automatically.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -394,10 +394,11 @@ All provider metadata (default model, API key env var, capabilities, model build
 
    Set `requiresBaseURL: true` if the provider needs a user-supplied endpoint (e.g. Azure), and add `baseUrlPromptMessage` if the generic prompt copy isn't clear enough.
 
-2. **Add the env var row** to `AGENTS.md` and `.env.example`.
-3. **Add the SDK dependency** to `core/package.json` if the provider needs a new `@ai-sdk/*` package.
-4. **Extend `core/tests/providerFactory.test.ts`**'s `EXPECTED_PROVIDER_TAG` map with the new provider's SDK `.provider` tag (run the test once to see what the AI SDK reports).
-5. **Add the provider to `runners/sdk/src/types.ts`**'s `ProviderName` union. The SDK can't import core's types directly (core isn't published to npm), so this one hand-copied union is the exception — everything else derives from the registry automatically.
+2. **Add the key to the `PROVIDERS` named-constant** in the same file (`{ MY_PROVIDER: "my-provider" }`). This `{ NAME: value }` object stays hand-written on purpose: it gives call sites literal-typed named access (`PROVIDERS.MY_PROVIDER`) and compile-time key checking that a derived `Object.fromEntries` view would lose. It's the one registry mirror not auto-derived — skip it and the `PROVIDER_CHOICES` test fails, and the extension popup dropdown / MCP tool-description list silently omit your provider.
+3. **Add the env var row** to `AGENTS.md` and `.env.example`.
+4. **Add the SDK dependency** to `core/package.json` if the provider needs a new `@ai-sdk/*` package.
+5. **Extend `core/tests/providerFactory.test.ts`**'s `EXPECTED_PROVIDER_TAG` map with the new provider's SDK `.provider` tag (run the test once to see what the AI SDK reports).
+6. **Add the provider to `runners/sdk/src/types.ts`**'s `ProviderName` union. The SDK can't import core's types directly (core isn't published to npm), so this one hand-copied union is the exception — everything else derives from the registry automatically.
 
 ---
 

--- a/core/src/browser.ts
+++ b/core/src/browser.ts
@@ -57,7 +57,16 @@ export { setEnvProvider, getEnv } from "./lib/env.js";
 export { randomUUID, randomTraceHex } from "./lib/random.js";
 export { newOtelTraceId } from "./lib/tracePropagation.js";
 
-export { createModel, PROVIDER_ENV_VARS, PROVIDER_DEFAULTS } from "./providers/factory.js";
-export type { LlmConfig } from "./config/types.js";
+export {
+  createModel,
+  PROVIDERS,
+  PROVIDER_ENV_VARS,
+  PROVIDER_DEFAULTS,
+  PROVIDER_CAPABILITIES,
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_BASE_URL_PROMPTS,
+  PROVIDER_CHOICES,
+} from "./providers/factory.js";
+export type { LlmConfig, ProviderName } from "./config/types.js";
 
 export { getAdapter } from "./telemetry/adapter.js";

--- a/core/src/config/types.ts
+++ b/core/src/config/types.ts
@@ -271,27 +271,9 @@ export interface TelemetryConfig {
   propagation?: TelemetryPropagationConfig;
 }
 
-export const PROVIDERS = {
-  OPENAI: "openai",
-  ANTHROPIC: "anthropic",
-  GROQ: "groq",
-  GOOGLE: "google",
-  DEEPSEEK: "deepseek",
-  AZURE: "azure",
-  OPENAI_COMPATIBLE: "openai-compatible",
-} as const;
-
-export type ProviderName = (typeof PROVIDERS)[keyof typeof PROVIDERS];
-
-export const PROVIDER_CHOICES: { name: string; value: ProviderName }[] = [
-  { name: "OpenAI", value: PROVIDERS.OPENAI },
-  { name: "Anthropic (Claude)", value: PROVIDERS.ANTHROPIC },
-  { name: "Google (Gemini)", value: PROVIDERS.GOOGLE },
-  { name: "Groq", value: PROVIDERS.GROQ },
-  { name: "DeepSeek", value: PROVIDERS.DEEPSEEK },
-  { name: "Azure OpenAI", value: PROVIDERS.AZURE },
-  { name: "Custom (OpenAI-compatible)", value: PROVIDERS.OPENAI_COMPATIBLE },
-];
+// Canonical definitions live in providers/factory.ts; re-exported so existing importers keep working.
+export { PROVIDERS, PROVIDER_CHOICES, type ProviderName } from "../providers/factory.js";
+import type { ProviderName } from "../providers/factory.js";
 
 /** Partial LLM config used in setup/config file inputs — all fields optional before resolution. */
 export interface LlmConfigInput {

--- a/core/src/lib/generateJsonObject.ts
+++ b/core/src/lib/generateJsonObject.ts
@@ -15,7 +15,7 @@ export interface JsonLlmMessage {
 export async function generateJsonObject(
   model: LanguageModel,
   messages: JsonLlmMessage[],
-  options?: { abortSignal?: AbortSignal }
+  options?: { abortSignal?: AbortSignal; temperature?: number }
 ): Promise<Record<string, unknown>> {
   const systemMsg = messages.find((m) => m.role === "system")?.content;
   const conversationMessages = messages
@@ -27,6 +27,7 @@ export async function generateJsonObject(
     output: "no-schema",
     ...(systemMsg ? { system: systemMsg } : {}),
     messages: conversationMessages,
+    ...(options?.temperature !== undefined ? { temperature: options.temperature } : {}),
     ...(options?.abortSignal ? { abortSignal: options.abortSignal } : {}),
   });
 

--- a/core/src/providers/factory.ts
+++ b/core/src/providers/factory.ts
@@ -10,7 +10,7 @@ import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createAzure } from "@ai-sdk/azure";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { PROVIDERS, type LlmConfig, type ProviderName } from "../config/types.js";
+import type { LlmConfig } from "../config/types.js";
 import { getEnv } from "../lib/env.js";
 
 export interface ProviderCapabilities {
@@ -32,9 +32,13 @@ export interface ProviderBuildContext {
  * editing a switch plus three parallel lookup tables (the old "5 files" problem).
  */
 export interface ProviderAdapter {
+  /** Human-readable label for provider-picker UIs (CLI wizard, extension popup). */
+  displayName: string;
   defaultModel: string;
   envVar: string;
   capabilities: ProviderCapabilities;
+  /** Prompt copy for `capabilities.requiresBaseURL`; falls back to a generic message when omitted. */
+  baseUrlPromptMessage?: string;
   /**
    * Custom message thrown by createModel when `capabilities.requiresBaseURL` is
    * set but no baseURL is supplied. Defaults to a generic message when omitted.
@@ -43,70 +47,96 @@ export interface ProviderAdapter {
   build(ctx: ProviderBuildContext): LanguageModel;
 }
 
-/** Table-driven provider dispatch — the single source of truth for all providers. */
-export const providerRegistry: Record<ProviderName, ProviderAdapter> = {
-  [PROVIDERS.OPENAI]: {
+// Unexported so `ProviderName` below can infer the literal key union; `providerRegistry`
+// re-declares it with an explicit `Record<ProviderName, ProviderAdapter>` annotation,
+// which avoids a non-portable nested `@ai-sdk/provider` type in the declaration emit.
+const providerRegistryData = {
+  openai: {
+    displayName: "OpenAI",
     defaultModel: "gpt-4o-mini",
     envVar: "OPENAI_API_KEY",
     capabilities: { supportsJsonMode: true, requiresBaseURL: false },
-    build: ({ apiKey, model }) => createOpenAI({ apiKey })(model),
+    build: ({ apiKey, model }): LanguageModel => createOpenAI({ apiKey })(model),
   },
-  [PROVIDERS.ANTHROPIC]: {
+  anthropic: {
+    displayName: "Anthropic (Claude)",
     defaultModel: "claude-3-5-haiku-20241022",
     envVar: "ANTHROPIC_API_KEY",
     capabilities: { supportsJsonMode: false, requiresBaseURL: false },
-    build: ({ apiKey, model }) => createAnthropic({ apiKey })(model),
+    build: ({ apiKey, model }): LanguageModel => createAnthropic({ apiKey })(model),
   },
-  [PROVIDERS.GROQ]: {
+  groq: {
+    displayName: "Groq",
     defaultModel: "llama-3.3-70b-versatile",
     envVar: "GROQ_API_KEY",
     capabilities: { supportsJsonMode: true, requiresBaseURL: false },
-    build: ({ apiKey, model }) =>
+    build: ({ apiKey, model }): LanguageModel =>
       createOpenAICompatible({
         name: "groq",
         apiKey,
         baseURL: "https://api.groq.com/openai/v1",
       }).chatModel(model),
   },
-  [PROVIDERS.GOOGLE]: {
+  google: {
+    displayName: "Google (Gemini)",
     defaultModel: "gemini-2.0-flash",
     envVar: "GOOGLE_GENERATIVE_AI_API_KEY",
     capabilities: { supportsJsonMode: false, requiresBaseURL: false },
-    build: ({ apiKey, model }) => createGoogleGenerativeAI({ apiKey })(model),
+    build: ({ apiKey, model }): LanguageModel => createGoogleGenerativeAI({ apiKey })(model),
   },
-  [PROVIDERS.DEEPSEEK]: {
+  deepseek: {
+    displayName: "DeepSeek",
     defaultModel: "deepseek-chat",
     envVar: "DEEPSEEK_API_KEY",
     capabilities: { supportsJsonMode: true, requiresBaseURL: false },
-    build: ({ apiKey, model }) => createDeepSeek({ apiKey })(model),
+    build: ({ apiKey, model }): LanguageModel => createDeepSeek({ apiKey })(model),
   },
-  [PROVIDERS.AZURE]: {
+  azure: {
+    displayName: "Azure OpenAI",
     defaultModel: "gpt-4o-mini",
     envVar: "AZURE_OPENAI_API_KEY",
     capabilities: { supportsJsonMode: true, requiresBaseURL: true },
-    baseUrlError: `baseURL is required for provider '${PROVIDERS.AZURE}' (Azure resource endpoint, e.g. https://<resource>.openai.azure.com)`,
+    baseUrlPromptMessage: "Azure resource endpoint (e.g. https://my-resource.openai.azure.com)",
+    baseUrlError: `baseURL is required for provider 'azure' (Azure resource endpoint, e.g. https://<resource>.openai.azure.com)`,
     // Add the /openai path when the endpoint has none; leave proxy/custom paths as-is.
-    build: ({ apiKey, model, baseURL }) => {
+    build: ({ apiKey, model, baseURL }): LanguageModel => {
       const base = baseURL!.replace(/\/+$/, "");
       let resolved: string;
       try {
         resolved = new URL(base).pathname === "/" ? `${base}/openai` : base;
       } catch {
         throw new Error(
-          `baseURL is not a valid URL for provider '${PROVIDERS.AZURE}' (Azure resource endpoint, e.g. https://<resource>.openai.azure.com)`
+          `baseURL is not a valid URL for provider 'azure' (Azure resource endpoint, e.g. https://<resource>.openai.azure.com)`
         );
       }
       return createAzure({ apiKey, baseURL: resolved })(model);
     },
   },
-  [PROVIDERS.OPENAI_COMPATIBLE]: {
+  "openai-compatible": {
+    displayName: "Custom (OpenAI-compatible)",
     defaultModel: "",
     envVar: "OPFOR_API_KEY",
     capabilities: { supportsJsonMode: true, requiresBaseURL: true },
-    build: ({ apiKey, model, baseURL }) =>
+    build: ({ apiKey, model, baseURL }): LanguageModel =>
       createOpenAICompatible({ name: "custom", apiKey, baseURL: baseURL! }).chatModel(model),
   },
-};
+} satisfies Record<string, ProviderAdapter>;
+
+/** Canonical provider key union, derived from the registry — no hand-maintained copy elsewhere. */
+export type ProviderName = keyof typeof providerRegistryData;
+
+export const providerRegistry: Record<ProviderName, ProviderAdapter> = providerRegistryData;
+
+/** `{ OPENAI: "openai", ... }`-style constant for call sites that prefer named access. */
+export const PROVIDERS = {
+  OPENAI: "openai",
+  ANTHROPIC: "anthropic",
+  GROQ: "groq",
+  GOOGLE: "google",
+  DEEPSEEK: "deepseek",
+  AZURE: "azure",
+  OPENAI_COMPATIBLE: "openai-compatible",
+} as const satisfies Record<string, ProviderName>;
 
 // Freeze the capability objects: the derived PROVIDER_CAPABILITIES aliases them,
 // so this keeps a stray `PROVIDER_CAPABILITIES.x.requiresBaseURL = …` from leaking
@@ -131,6 +161,17 @@ export const PROVIDER_ENV_VARS: Record<ProviderName, string> = projectRegistry((
 export const PROVIDER_CAPABILITIES: Record<ProviderName, ProviderCapabilities> = projectRegistry(
   (a) => a.capabilities
 );
+export const PROVIDER_DISPLAY_NAMES: Record<ProviderName, string> = projectRegistry(
+  (a) => a.displayName
+);
+export const PROVIDER_BASE_URL_PROMPTS: Record<ProviderName, string | undefined> = projectRegistry(
+  (a) => a.baseUrlPromptMessage
+);
+
+/** `{ name, value }[]` shape consumed directly by the CLI wizard's `select()` prompt. */
+export const PROVIDER_CHOICES: { name: string; value: ProviderName }[] = (
+  Object.keys(providerRegistry) as ProviderName[]
+).map((value) => ({ name: PROVIDER_DISPLAY_NAMES[value], value }));
 
 /** Returns an error message string if the config is invalid, or null if valid. */
 export function validateLlmConfig(llm: LlmConfig): string | null {

--- a/core/tests/providerFactory.test.ts
+++ b/core/tests/providerFactory.test.ts
@@ -20,6 +20,9 @@ const {
   PROVIDER_DEFAULTS,
   PROVIDER_ENV_VARS,
   PROVIDER_CAPABILITIES,
+  PROVIDER_DISPLAY_NAMES,
+  PROVIDER_BASE_URL_PROMPTS,
+  PROVIDER_CHOICES,
 } = await import("../src/providers/factory.js");
 const { PROVIDERS } = await import("../src/config/types.js");
 
@@ -84,6 +87,33 @@ test("the three lookup tables keep their exact values", () => {
     azure: { supportsJsonMode: true, requiresBaseURL: true },
     "openai-compatible": { supportsJsonMode: true, requiresBaseURL: true },
   });
+});
+
+test("every provider has a display name; only baseURL-requiring providers may have a prompt message", () => {
+  for (const provider of Object.values(PROVIDERS)) {
+    assert.ok(
+      PROVIDER_DISPLAY_NAMES[provider] && PROVIDER_DISPLAY_NAMES[provider].length > 0,
+      `${provider} is missing a displayName`
+    );
+    if (PROVIDER_BASE_URL_PROMPTS[provider] !== undefined) {
+      assert.ok(
+        PROVIDER_CAPABILITIES[provider].requiresBaseURL,
+        `${provider} has a baseUrlPromptMessage but doesn't require a baseURL`
+      );
+    }
+  }
+  assert.ok(PROVIDER_CAPABILITIES.azure.requiresBaseURL && PROVIDER_BASE_URL_PROMPTS.azure);
+});
+
+test("PROVIDER_CHOICES lists every provider once, matching PROVIDER_DISPLAY_NAMES", () => {
+  assert.strictEqual(PROVIDER_CHOICES.length, Object.values(PROVIDERS).length);
+  assert.deepStrictEqual(
+    new Set(PROVIDER_CHOICES.map((c) => c.value)),
+    new Set(Object.values(PROVIDERS))
+  );
+  for (const choice of PROVIDER_CHOICES) {
+    assert.strictEqual(choice.name, PROVIDER_DISPLAY_NAMES[choice.value]);
+  }
 });
 
 test("createModel throws when apiKeyEnv is missing", () => {

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -173,7 +173,7 @@ Runs the full red team evaluation from a config file produced by `opfor_setup`. 
 | Groq               | `groq`              | `GROQ_API_KEY`                       |
 | Google (Gemini)    | `google`            | `GOOGLE_GENERATIVE_AI_API_KEY`       |
 | DeepSeek           | `deepseek`          | `DEEPSEEK_API_KEY`                   |
-| Azure OpenAI       | `azure`             | `AZURE_API_KEY`                      |
+| Azure OpenAI       | `azure`             | `AZURE_OPENAI_API_KEY`               |
 | OpenAI-compatible  | `openai-compatible` | (set via `api_key_env` + `base_url`) |
 
 ---

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -308,7 +308,7 @@ attackerModel: { provider: "openai", model: "gpt-4o", apiKeyEnv: "OPENAI_API_KEY
 attackerModel: { provider: "anthropic", model: "claude-sonnet-4", apiKeyEnv: "ANTHROPIC_API_KEY" }
 
 // Google
-attackerModel: { provider: "google", model: "gemini-2.0-flash", apiKeyEnv: "GOOGLE_API_KEY" }
+attackerModel: { provider: "google", model: "gemini-2.0-flash", apiKeyEnv: "GOOGLE_GENERATIVE_AI_API_KEY" }
 
 // Groq
 attackerModel: { provider: "groq", model: "llama-3.3-70b", apiKeyEnv: "GROQ_API_KEY" }
@@ -320,7 +320,7 @@ attackerModel: { provider: "deepseek", model: "deepseek-chat", apiKeyEnv: "DEEPS
 attackerModel: {
   provider: "azure",
   model: "gpt-4o",
-  apiKeyEnv: "AZURE_API_KEY",
+  apiKeyEnv: "AZURE_OPENAI_API_KEY",
   baseUrl: "https://my-resource.openai.azure.com"
 }
 

--- a/runners/cli/src/commands/setup.ts
+++ b/runners/cli/src/commands/setup.ts
@@ -5,7 +5,6 @@ import { input, select, checkbox, confirm } from "@inquirer/prompts";
 import { log } from "@keyvaluesystems/agent-opfor-core/lib/logger.js";
 import { loadSkillCatalog } from "@keyvaluesystems/agent-opfor-core/config/loadSkillCatalog.js";
 import {
-  PROVIDERS,
   PROVIDER_CHOICES,
   type LlmConfig,
   type ProviderName,
@@ -16,6 +15,8 @@ import {
 import {
   PROVIDER_DEFAULTS,
   PROVIDER_ENV_VARS,
+  PROVIDER_CAPABILITIES,
+  PROVIDER_BASE_URL_PROMPTS,
 } from "@keyvaluesystems/agent-opfor-core/providers/factory.js";
 import type {
   RunConfig,
@@ -226,11 +227,8 @@ async function collectLlmConfig(label: string): Promise<LlmConfig> {
   });
 
   let baseURL: string | undefined;
-  if (provider === PROVIDERS.AZURE || provider === PROVIDERS.OPENAI_COMPATIBLE) {
-    const message =
-      provider === PROVIDERS.AZURE
-        ? "Azure resource endpoint (e.g. https://my-resource.openai.azure.com)"
-        : "Base URL (required for this provider)";
+  if (PROVIDER_CAPABILITIES[provider].requiresBaseURL) {
+    const message = PROVIDER_BASE_URL_PROMPTS[provider] ?? "Base URL (required for this provider)";
     baseURL = await input({
       message,
       validate: (v) => (v.trim() ? true : "A value is required"),

--- a/runners/extension/config.js
+++ b/runners/extension/config.js
@@ -1,13 +1,4 @@
-import { PROVIDERS } from "./providers.js";
-
-/** Providers whose endpoint is hardcoded — no baseUrl required from the user. */
-const PROVIDERS_WITH_FIXED_URL = new Set([
-  PROVIDERS.OPENAI,
-  PROVIDERS.ANTHROPIC,
-  PROVIDERS.GROQ,
-  PROVIDERS.GOOGLE,
-  PROVIDERS.DEEPSEEK,
-]);
+import { PROVIDERS, PROVIDER_CAPABILITIES } from "./dist/core.bundle.js";
 
 /**
  * Load per-task LLM configs from Options storage.
@@ -38,7 +29,7 @@ export async function getLlmProfile(kind) {
 
 export function assertLlmCfg(cfg, { kind }) {
   if (!cfg?.enabled) throw new Error(`${kind} LLM is disabled (enable it in extension Options).`);
-  if (!PROVIDERS_WITH_FIXED_URL.has(cfg.provider) && !cfg.baseUrl) {
+  if (PROVIDER_CAPABILITIES[cfg.provider]?.requiresBaseURL && !cfg.baseUrl) {
     throw new Error(`${kind} LLM missing baseUrl in Options.`);
   }
   if (!cfg.model) throw new Error(`${kind} LLM missing model in Options.`);

--- a/runners/extension/llm.js
+++ b/runners/extension/llm.js
@@ -1,10 +1,18 @@
 import {
   createModel,
   generateJsonObject,
+  PROVIDERS,
   PROVIDER_ENV_VARS,
   setEnvProvider,
 } from "./dist/core.bundle.js";
 import { state } from "./state.js";
+
+// 0 for determinism, except gpt-5 (LiteLLM/OpenAI reject 0) and Anthropic (left unset).
+function providerTemperature(provider, model) {
+  if (provider === PROVIDERS.ANTHROPIC) return undefined;
+  if (/gpt-5/i.test(String(model || ""))) return 1;
+  return 0;
+}
 
 /** Calls a provider/model and returns the parsed JSON response — same dispatch orchestrator.js uses for the attacker/judge models. */
 export async function callLlm({ provider, baseUrl, apiKey, model, messages, signal: signalOpt }) {
@@ -18,7 +26,10 @@ export async function callLlm({ provider, baseUrl, apiKey, model, messages, sign
     baseURL: baseUrl || undefined,
   });
   try {
-    return await generateJsonObject(llmModel, messages, { abortSignal: signal });
+    return await generateJsonObject(llmModel, messages, {
+      abortSignal: signal,
+      temperature: providerTemperature(provider, model),
+    });
   } catch (e) {
     if (e?.name === "AbortError" || state.OPFOR_STOP) throw new Error("Run stopped.", { cause: e });
     throw e;

--- a/runners/extension/llm.js
+++ b/runners/extension/llm.js
@@ -1,174 +1,26 @@
-import { safeJsonParse } from "./utils.js";
+import {
+  createModel,
+  generateJsonObject,
+  PROVIDER_ENV_VARS,
+  setEnvProvider,
+} from "./dist/core.bundle.js";
 import { state } from "./state.js";
-import { PROVIDERS } from "./providers.js";
 
-export async function callOpenAiCompat({ baseUrl, apiKey, model, messages, signal: signalOpt }) {
-  const url = `${baseUrl.replace(/\/+$/, "")}/chat/completions`;
+/** Calls a provider/model and returns the parsed JSON response — same dispatch orchestrator.js uses for the attacker/judge models. */
+export async function callLlm({ provider, baseUrl, apiKey, model, messages, signal: signalOpt }) {
   const signal = signalOpt ?? state.uiRunAbortController?.signal;
-  const modelStr = String(model || "");
-  // Some OpenAI-compatible routers (e.g. LiteLLM) reject temperature=0 for gpt-5 family.
-  const temperature = /gpt-5/i.test(modelStr) ? 1 : 0;
-  let resp;
+  const envVar = PROVIDER_ENV_VARS[provider] ?? "OPFOR_API_KEY";
+  setEnvProvider((name) => (name === envVar ? apiKey : undefined));
+  const llmModel = createModel({
+    provider,
+    model,
+    apiKeyEnv: envVar,
+    baseURL: baseUrl || undefined,
+  });
   try {
-    resp = await fetch(url, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
-      },
-      body: JSON.stringify({
-        model,
-        temperature,
-        response_format: { type: "json_object" },
-        messages,
-      }),
-      signal,
-    });
+    return await generateJsonObject(llmModel, messages, { abortSignal: signal });
   } catch (e) {
     if (e?.name === "AbortError" || state.OPFOR_STOP) throw new Error("Run stopped.", { cause: e });
     throw e;
-  }
-
-  const text = await resp.text();
-  if (!resp.ok) {
-    throw new Error(`LLM request failed (${resp.status}): ${text.slice(0, 500)}`);
-  }
-  const parsed = safeJsonParse(text);
-  if (!parsed.ok) throw new Error(`LLM response not JSON: ${parsed.error}`);
-
-  const content = parsed.value?.choices?.[0]?.message?.content;
-  if (typeof content !== "string") throw new Error("LLM response missing message.content");
-
-  const contentParsed = safeJsonParse(content);
-  if (!contentParsed.ok) throw new Error(`LLM message.content not JSON: ${contentParsed.error}`);
-  return contentParsed.value;
-}
-
-export async function callAnthropic({ apiKey, model, messages, signal: signalOpt }) {
-  const signal = signalOpt ?? state.uiRunAbortController?.signal;
-  const systemMsg = messages.find((m) => m.role === "system")?.content;
-  const userMessages = messages.filter((m) => m.role !== "system");
-
-  let resp;
-  try {
-    resp = await fetch("https://api.anthropic.com/v1/messages", {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "x-api-key": apiKey,
-        "anthropic-version": "2023-06-01",
-      },
-      body: JSON.stringify({
-        model,
-        max_tokens: 1024,
-        ...(systemMsg ? { system: systemMsg } : {}),
-        messages: userMessages,
-      }),
-      signal,
-    });
-  } catch (e) {
-    if (e?.name === "AbortError" || state.OPFOR_STOP) throw new Error("Run stopped.", { cause: e });
-    throw e;
-  }
-
-  const text = await resp.text();
-  if (!resp.ok) throw new Error(`LLM request failed (${resp.status}): ${text.slice(0, 500)}`);
-
-  const parsed = safeJsonParse(text);
-  if (!parsed.ok) throw new Error(`LLM response not JSON: ${parsed.error}`);
-
-  const content = parsed.value?.content?.[0]?.text;
-  if (typeof content !== "string") throw new Error("LLM response missing content text");
-
-  const contentParsed = safeJsonParse(content);
-  if (!contentParsed.ok) throw new Error(`LLM message.content not JSON: ${contentParsed.error}`);
-  return contentParsed.value;
-}
-
-export async function callGoogle({ apiKey, model, messages, signal: signalOpt }) {
-  const signal = signalOpt ?? state.uiRunAbortController?.signal;
-  const systemMsg = messages.find((m) => m.role === "system")?.content;
-  const userMessages = messages.filter((m) => m.role !== "system");
-
-  const contents = userMessages.map((m) => ({
-    role: m.role === "assistant" ? "model" : "user",
-    parts: [{ text: m.content }],
-  }));
-
-  const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
-
-  let resp;
-  try {
-    resp = await fetch(url, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({
-        ...(systemMsg ? { systemInstruction: { parts: [{ text: systemMsg }] } } : {}),
-        contents,
-        generationConfig: { temperature: 0 },
-      }),
-      signal,
-    });
-  } catch (e) {
-    if (e?.name === "AbortError" || state.OPFOR_STOP) throw new Error("Run stopped.", { cause: e });
-    throw e;
-  }
-
-  const text = await resp.text();
-  if (!resp.ok) throw new Error(`LLM request failed (${resp.status}): ${text.slice(0, 500)}`);
-
-  const parsed = safeJsonParse(text);
-  if (!parsed.ok) throw new Error(`LLM response not JSON: ${parsed.error}`);
-
-  const content = parsed.value?.candidates?.[0]?.content?.parts?.[0]?.text;
-  if (typeof content !== "string") throw new Error("LLM response missing content text");
-
-  const contentParsed = safeJsonParse(content);
-  if (!contentParsed.ok) throw new Error(`LLM message.content not JSON: ${contentParsed.error}`);
-  return contentParsed.value;
-}
-
-/** Routes to the right provider implementation based on cfg.provider. */
-export async function callLlm({ provider, baseUrl, apiKey, model, messages, signal }) {
-  switch (provider) {
-    case PROVIDERS.ANTHROPIC:
-      return callAnthropic({ apiKey, model, messages, signal });
-    case PROVIDERS.GOOGLE:
-      return callGoogle({ apiKey, model, messages, signal });
-    case PROVIDERS.DEEPSEEK:
-      return callOpenAiCompat({
-        baseUrl: "https://api.deepseek.com/v1",
-        apiKey,
-        model,
-        messages,
-        signal,
-      });
-    case PROVIDERS.AZURE: {
-      // Add the /openai path when the endpoint has none, then the deployment segment.
-      const base = baseUrl.replace(/\/+$/, "");
-      let root;
-      try {
-        root = new URL(base).pathname === "/" ? `${base}/openai` : base;
-      } catch {
-        throw new Error(
-          `Azure baseUrl is not a valid URL (e.g. https://<resource>.openai.azure.com)`
-        );
-      }
-      return callOpenAiCompat({
-        baseUrl: `${root}/deployments/${model}`,
-        apiKey,
-        model,
-        messages,
-        signal,
-      });
-    }
-    default:
-      return callOpenAiCompat({
-        baseUrl: baseUrl || "https://api.openai.com/v1",
-        apiKey,
-        model,
-        messages,
-        signal,
-      });
   }
 }

--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -6,18 +6,14 @@
 // OPFOR_UI_RUN / RESUME / STOP / DISCARD_PAUSED message contracts.
 // ─────────────────────────────────────────────────────────────────
 
-import { PROVIDERS } from "./providers.js";
+import { PROVIDERS, PROVIDER_CAPABILITIES, PROVIDER_DISPLAY_NAMES } from "./dist/core.bundle.js";
 
-const PROVIDER_OPTIONS = [
-  { value: PROVIDERS.OPENAI, label: "OpenAI" },
-  { value: PROVIDERS.ANTHROPIC, label: "Anthropic" },
-  { value: PROVIDERS.GOOGLE, label: "Google (Gemini)" },
-  { value: PROVIDERS.GROQ, label: "Groq" },
-  { value: PROVIDERS.DEEPSEEK, label: "DeepSeek" },
-  { value: PROVIDERS.AZURE, label: "Azure OpenAI" },
-  { value: PROVIDERS.OPENAI_COMPATIBLE, label: "Custom (OpenAI-compatible)" },
-];
+const PROVIDER_OPTIONS = Object.values(PROVIDERS).map((value) => ({
+  value,
+  label: PROVIDER_DISPLAY_NAMES[value],
+}));
 
+// Extension-only model lists/defaults — deliberately not sourced from core's PROVIDER_DEFAULTS.
 const MODELS_BY_PROVIDER = {
   [PROVIDERS.OPENAI]: ["gpt-4o-mini", "gpt-4o", "gpt-4.1", "gpt-5"],
   [PROVIDERS.ANTHROPIC]: [
@@ -44,7 +40,9 @@ const PROVIDER_DEFAULT_MODELS = {
 };
 
 /** Providers that require a user-supplied baseUrl. */
-const PROVIDERS_NEEDING_BASE_URL = new Set([PROVIDERS.AZURE, PROVIDERS.OPENAI_COMPATIBLE]);
+const PROVIDERS_NEEDING_BASE_URL = new Set(
+  Object.values(PROVIDERS).filter((p) => PROVIDER_CAPABILITIES[p].requiresBaseURL)
+);
 
 /** Providers whose models are fetched dynamically from a known endpoint. */
 const SIMPLE_PROVIDER_FETCH_CONFIG = {

--- a/runners/extension/providers.js
+++ b/runners/extension/providers.js
@@ -1,9 +1,0 @@
-export const PROVIDERS = {
-  OPENAI: "openai",
-  ANTHROPIC: "anthropic",
-  GROQ: "groq",
-  GOOGLE: "google",
-  DEEPSEEK: "deepseek",
-  AZURE: "azure",
-  OPENAI_COMPATIBLE: "openai-compatible",
-};

--- a/runners/mcp/src/index.ts
+++ b/runners/mcp/src/index.ts
@@ -125,7 +125,7 @@ server.tool(
     "EVALUATORS\n" +
     "  9. Call opfor_list_evaluators with the chosen target_kind, present the suites and evaluators to the user, then ask: run a full suite or specific evaluators?\n" +
     "ATTACKER LLM\n" +
-    " 10. Provider — options: openai, anthropic, groq, google, deepseek, azure, openai-compatible.\n" +
+    ` 10. Provider — options: ${Object.values(PROVIDERS).join(", ")}.\n` +
     " 11. Model name for that provider.\n" +
     " 12. Name of the environment variable that holds the API key (e.g. OPENAI_API_KEY).\n" +
     " 13. (openai-compatible or azure only) Base URL.\n" +

--- a/runners/sdk/src/run.ts
+++ b/runners/sdk/src/run.ts
@@ -6,6 +6,10 @@ import type {
   EvaluatorSelection,
 } from "@keyvaluesystems/agent-opfor-core";
 import type { LlmConfig, ProviderName } from "@keyvaluesystems/agent-opfor-core/config/types.js";
+import {
+  PROVIDER_ENV_VARS,
+  PROVIDER_DEFAULTS,
+} from "@keyvaluesystems/agent-opfor-core/providers/factory.js";
 import type {
   RunOptions,
   RunResults,
@@ -17,7 +21,7 @@ import type {
 } from "./types.js";
 
 const DEFAULT_PROVIDER: ProviderName = "anthropic";
-const DEFAULT_MODEL = "claude-sonnet-4-20250514";
+const DEFAULT_MODEL = PROVIDER_DEFAULTS[DEFAULT_PROVIDER];
 
 /**
  * Run adversarial tests against a target.
@@ -109,7 +113,7 @@ function buildLlmConfig(model: ModelSpec | undefined, defaultApiKey?: string): L
     return {
       provider: DEFAULT_PROVIDER,
       model: DEFAULT_MODEL,
-      apiKeyEnv: defaultApiKey ? "" : "ANTHROPIC_API_KEY",
+      apiKeyEnv: defaultApiKey ? "" : PROVIDER_ENV_VARS[DEFAULT_PROVIDER],
     };
   }
 
@@ -118,14 +122,14 @@ function buildLlmConfig(model: ModelSpec | undefined, defaultApiKey?: string): L
     return {
       provider,
       model,
-      apiKeyEnv: defaultApiKey ? "" : getDefaultApiKeyEnv(provider),
+      apiKeyEnv: defaultApiKey ? "" : PROVIDER_ENV_VARS[provider],
     };
   }
 
   return {
     provider: model.provider,
     model: model.model,
-    apiKeyEnv: model.apiKeyEnv ?? (defaultApiKey ? "" : getDefaultApiKeyEnv(model.provider)),
+    apiKeyEnv: model.apiKeyEnv ?? (defaultApiKey ? "" : PROVIDER_ENV_VARS[model.provider]),
     baseURL: model.baseUrl,
   };
 }
@@ -140,19 +144,6 @@ function inferProvider(model: string): ProviderName {
   if (lower.includes("deepseek")) return "deepseek";
 
   return "anthropic";
-}
-
-function getDefaultApiKeyEnv(provider: ProviderName): string {
-  const envVars: Record<ProviderName, string> = {
-    anthropic: "ANTHROPIC_API_KEY",
-    openai: "OPENAI_API_KEY",
-    google: "GOOGLE_API_KEY",
-    groq: "GROQ_API_KEY",
-    deepseek: "DEEPSEEK_API_KEY",
-    azure: "AZURE_API_KEY",
-    "openai-compatible": "LLM_API_KEY",
-  };
-  return envVars[provider] ?? "ANTHROPIC_API_KEY";
 }
 
 function transformReport(


### PR DESCRIPTION
## Problem

Adding a new LLM provider touched several files instead of one: `PROVIDERS`/`PROVIDER_CHOICES` were hand-maintained separately in `core/src/config/types.ts`, the CLI wizard hardcoded an Azure/OpenAI-compatible branch for the baseURL prompt, the browser extension had a fully independent provider system (its own `PROVIDERS` const, default-model/label/baseURL lists, and ~170 lines of hand-rolled per-provider `fetch()` + JSON-parsing logic), and the SDK hand-duplicated `ProviderName`/env-var defaults that had already drifted from core on 3 providers (`google`, `azure`, `openai-compatible`).

## Solution

`providerRegistryData` in `core/src/providers/factory.ts` is now the actual source of truth — `PROVIDERS`, `ProviderName`, `PROVIDER_CHOICES`, `PROVIDER_DISPLAY_NAMES`, `PROVIDER_DEFAULTS`, `PROVIDER_ENV_VARS`, `PROVIDER_CAPABILITIES`, and `PROVIDER_BASE_URL_PROMPTS` all derive from one object literal. Every other surface now reads from it instead of hand-maintaining its own copy:

- **CLI wizard** uses `PROVIDER_CAPABILITIES`/`PROVIDER_BASE_URL_PROMPTS` instead of a hardcoded Azure/OpenAI-compatible branch.
- **MCP server** derives its tool-description provider list instead of a hardcoded string.
- **Browser extension**: deleted `providers.js` entirely; replaced `llm.js`'s hand-rolled per-provider fetch/JSON-parsing with core's `createModel` + `generateJsonObject` (the same dispatch already used for the attacker/judge models); `config.js`/`popup.js` now read provider metadata from the bundled core.
- **SDK**: fixed the drifted `getDefaultApiKeyEnv()` map by importing core's real `PROVIDER_ENV_VARS`/`PROVIDER_DEFAULTS` directly (same subpath import the CLI already uses). `ProviderName`/`LlmConfig` stay hand-copied in the SDK's public types (core isn't published to npm, so this one union is a documented, deliberate exception — noted in CONTRIBUTING.md).

Two small, unrelated pre-existing bugs were fixed along the way because they blocked verifying this work end-to-end: a `z.record()` call in `runners/mcp/src/index.ts` needed a second argument under zod v4 (same class of bug already fixed elsewhere in `bcd970e`, branch rebased onto that fix).

## Changes

- `core/src/providers/factory.ts` — registry flip, new `displayName`/`baseUrlPromptMessage` fields, new derived exports
- `core/src/config/types.ts` — re-exports from factory.ts instead of hand-maintaining `PROVIDERS`
- `core/src/browser.ts` — exports the full provider-metadata surface for the extension bundle
- `core/tests/providerFactory.test.ts` — new assertions for `displayName`/`PROVIDER_CHOICES`/`baseUrlPromptMessage`
- `runners/cli/src/commands/setup.ts` — drops the hardcoded baseURL branch
- `runners/mcp/src/index.ts` — derives the provider list in the tool description
- `runners/extension/{llm.js,providers.js,config.js,popup.js}` — deletes `providers.js`, guts `llm.js`'s duplicate fetch logic, sources metadata from the core bundle
- `runners/sdk/src/run.ts` — fixes the drifted env-var map and default model via core's real registry
- `docs/mcp.md`, `docs/sdk.md` — corrected wrong `azure`/`google` env var values
- `CONTRIBUTING.md` — new "Adding an LLM provider" section

## Issue

N/A

## How to test

- `npm run build` from repo root — full monorepo build (core → CLI → MCP → SDK → extension bundle)
- `npm test` (core) — 139/139 passing, includes new provider-registry assertions
- `npm run typecheck && npm run lint && npm run format:check` — all clean
- `opfor setup --agent` — walk the wizard, confirm Azure shows its resource-endpoint hint and a non-baseURL provider shows no prompt
- Load `runners/extension/` unpacked in Chrome, confirm the provider dropdown still lists all 7 providers with the same labels, and run one attack against `tests/e2e/agents/vanilla-chat` to confirm the input-picker/message-shortener/business-context LLM calls still work after the `llm.js` rewrite

## Screenshots

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider setup and selection now use a broader, more consistent provider list with clearer display names.
  * Providers that need a base URL now show a tailored prompt during setup.

* **Bug Fixes**
  * Improved provider validation so missing API keys or base URLs are caught more reliably.
  * Updated default provider configuration handling for more consistent behavior across tools.

* **Documentation**
  * Added guidance for adding new LLM providers.
  * Corrected environment variable names in provider setup docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->