### PR TITLE
feat: support local-script targets in opfor hunt

### DIFF
--- a/core/src/autonomous/lib/types.ts
+++ b/core/src/autonomous/lib/types.ts
@@ -6,15 +6,26 @@ import type { SessionConfig } from "../../execute/types.js";
 /** How the target HTTP agent maintains conversation state. */
 export type TargetMode = "stateless" | "stateful";
 
+/** "http" (default) sends real HTTP requests; "local-script" shells out to `scriptPath` instead. */
+export type TargetKind = "http" | "local-script";
+
 /**
  * Transport configuration for the target agent under test.
  * The agent (Claude SDK) never sees these values — tools hold the client.
  */
 export interface TargetConfig {
-  /** Display name (defaults to the endpoint host). */
+  /** Display name (defaults to the endpoint host, or the script's basename for local-script). */
   name: string;
-  /** Target HTTP endpoint URL. */
+  /** "http" (default) or "local-script". */
+  type?: TargetKind;
+  /**
+   * Target HTTP endpoint URL (`type: "http"`), or a synthetic display string
+   * (`local-script:<scriptPath>`) for `type: "local-script"` — report/UI/prompt
+   * code treats this as an opaque label, never parses it as a real URL.
+   */
   endpoint: string;
+  /** Path to a `.js`/`.py` adapter script (`type: "local-script"` only). See docs/sessions.md. */
+  scriptPath?: string;
   /** Bearer API key sent as `Authorization: Bearer <key>` (optional). */
   apiKey?: string;
   /** Extra static headers merged into every request. */

--- a/core/src/autonomous/target/http.ts
+++ b/core/src/autonomous/target/http.ts
@@ -10,6 +10,7 @@ import {
 } from "../../targets/httpClient.js";
 import type { TargetConfig } from "../lib/types.js";
 import { log } from "../../lib/logger.js";
+import { createLocalScriptTargetClient } from "./localScript.js";
 
 export type { HttpTargetMessage as TargetMessage };
 export type { HttpSendResult as TargetSendResult };
@@ -38,6 +39,7 @@ function toHttpConfig(config: TargetConfig): HttpTargetConfig {
 }
 
 export function createTargetClient(config: TargetConfig): TargetClient {
+  if (config.type === "local-script") return createLocalScriptTargetClient(config);
   const httpConfig = toHttpConfig(config);
   const plan = resolveSessionPlan(httpConfig);
   // Server-owned targets mint their own id, so threadId can't be the wire id.

--- a/core/src/autonomous/target/localScript.ts
+++ b/core/src/autonomous/target/localScript.ts
@@ -11,7 +11,9 @@ import type { TargetClient, TargetSendOptions } from "./http.js";
 
 export function createLocalScriptTargetClient(config: TargetConfig): TargetClient {
   if (!config.scriptPath) {
-    throw new Error("local-script target is missing `scriptPath`.");
+    throw new Error(
+      'local-script target is missing `scriptPath`. Set it on the target in --target-config, e.g. { "type": "local-script", "scriptPath": "./adapter.js" }.'
+    );
   }
   const scriptPath = config.scriptPath;
 

--- a/core/src/autonomous/target/localScript.ts
+++ b/core/src/autonomous/target/localScript.ts
@@ -1,0 +1,37 @@
+// Local-script target client for `opfor hunt` — same TargetClient interface as
+// the HTTP client (./http.ts), but shells out to a user script per turn instead
+// of making an HTTP request. Shares the stdin/stdout contract documented for
+// `opfor run`'s local-script targets (see core/src/lib/localScriptTarget.ts).
+
+import { invokeLocalTargetScript } from "../../lib/localScriptTarget.js";
+import { isTargetError, RATE_LIMITED_SENTINEL } from "../../targets/agentTarget.js";
+import type { HttpSendResult } from "../../targets/httpClient.js";
+import type { TargetConfig } from "../lib/types.js";
+import type { TargetClient, TargetSendOptions } from "./http.js";
+
+export function createLocalScriptTargetClient(config: TargetConfig): TargetClient {
+  if (!config.scriptPath) {
+    throw new Error("local-script target is missing `scriptPath`.");
+  }
+  const scriptPath = config.scriptPath;
+
+  return {
+    async send(prompt: string, options: TargetSendOptions): Promise<HttpSendResult> {
+      // The script owns its own conversation history/session, keyed by sessionId
+      // (same contract `opfor run` uses). threadId doubles as that session id, so
+      // hunt's per-thread forking works for free: each forked thread gets its own
+      // threadId and the script sees it as a distinct session.
+      const response = await invokeLocalTargetScript(scriptPath, {
+        prompt,
+        sessionId: options.threadId,
+      });
+      const isError = isTargetError(response);
+      return {
+        response,
+        isError,
+        rateLimited: response === RATE_LIMITED_SENTINEL,
+        errorMessage: isError ? response : undefined,
+      };
+    },
+  };
+}

--- a/core/src/lib/localScriptTarget.ts
+++ b/core/src/lib/localScriptTarget.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-const TIMEOUT_MS = 30_000;
+const TIMEOUT_MS = 240_000;
 
 /** Reads the shebang line of a file, returns the interpreter path or null. */
 function readShebang(absPath: string): string | null {
@@ -99,7 +99,7 @@ export async function invokeLocalTargetScript(
       }
       try {
         const j = JSON.parse(trimmed) as { response?: unknown; error?: unknown };
-        if (j.error != null) finish(String(j.error));
+        if (j.error != null) finish(`ERROR: ${String(j.error)}`);
         else if (j.response != null) finish(String(j.response));
         else finish(trimmed);
       } catch {

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -26,18 +26,18 @@ Add `--ui` to watch the attack tree unfold in a live dashboard.
 
 ### Target
 
-| Option                       | Description                                                                       |
-| ---------------------------- | --------------------------------------------------------------------------------- |
-| `--endpoint <url>`           | Target HTTP endpoint (required)                                                   |
-| `--objective <text>`         | Attack objective                                                                  |
-| `--objective-file <path>`    | Read objective from file                                                          |
-| `--target-key-env <var>`     | Env var with target API key                                                       |
-| `--target-key <key>`         | Target API key directly                                                           |
-| `--name <name>`              | Display name for target                                                           |
-| `--target-model <id>`        | Model value in requests                                                           |
-| `--stateless` / `--stateful` | History handling mode                                                             |
-| `--session-field <name>`     | Body field for the session id (client-owned, stateful)                            |
-| `--target-config <path>`     | JSON file with a run-style `target` block; enables server-owned & header sessions |
+| Option                       | Description                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `--endpoint <url>`           | Target HTTP endpoint (required unless a local-script target is given via `--target-config`)                 |
+| `--objective <text>`         | Attack objective                                                                                            |
+| `--objective-file <path>`    | Read objective from file                                                                                    |
+| `--target-key-env <var>`     | Env var with target API key                                                                                 |
+| `--target-key <key>`         | Target API key directly                                                                                     |
+| `--name <name>`              | Display name for target                                                                                     |
+| `--target-model <id>`        | Model value in requests                                                                                     |
+| `--stateless` / `--stateful` | History handling mode                                                                                       |
+| `--session-field <name>`     | Body field for the session id (client-owned, stateful)                                                      |
+| `--target-config <path>`     | JSON file with a run-style `target` block; enables server-owned & header sessions, and local-script targets |
 
 ### Session handling
 
@@ -73,6 +73,36 @@ opfor hunt --target-config target.json --objective "Probe for jailbreaks and saf
 The `--ui` setup form also has a Session section. See **[Target session handling](sessions.md)** for
 the full model. Note: because a server-owned session belongs to the target, forking an attack thread
 opens a **new** server session.
+
+### Local-script targets
+
+For targets that can't be modeled as a simple HTTP request/response — async/polling APIs, session ids
+embedded in a URL path segment, or auth flows needing custom logic — point `opfor hunt` at a local
+script adapter instead of an endpoint, using the same `type: "local-script"` shape and stdin/stdout
+contract as `opfor run` (see [Local target scripts](cli.md#local-target-scripts-js--py---agent-mode)).
+
+```jsonc
+// target.json
+{
+  "target": {
+    "kind": "agent",
+    "type": "local-script",
+    "scriptPath": "./opfor-local-target.js",
+  },
+}
+```
+
+```bash
+opfor hunt --target-config target.json --objective "Probe for jailbreaks and safety bypasses."
+```
+
+There is no `--endpoint`, `--script-path`, or similar CLI flag for this — local-script targets are only
+configured via `--target-config`. `--name` still works to override the display name (defaults to the
+script's basename otherwise).
+
+Hunt's per-thread `threadId` is passed to the script as `sessionId`, so each forked attack thread gets
+an isolated session automatically — no extra wiring needed. The script has 240 seconds per turn to
+respond before it's killed.
 
 ### Models
 

--- a/runners/cli/src/commands/hunt.ts
+++ b/runners/cli/src/commands/hunt.ts
@@ -74,7 +74,20 @@ function parseHeaders(raw?: string[]): Record<string, string> | undefined {
 // and resolves the API key from `apiKeyEnv` (the file holds the var name).
 function mapAgentTargetToAutonomous(t: ReturnType<typeof parseAgentTarget>): TargetConfig {
   if (t.type === "local-script") {
-    throw new Error("local-script targets are not supported by `opfor hunt` (HTTP only).");
+    if (!t.scriptPath) throw new Error("local-script target is missing `scriptPath`.");
+    return {
+      name: t.name || path.basename(t.scriptPath),
+      type: "local-script",
+      scriptPath: t.scriptPath,
+      // Report/UI/prompt code treats `endpoint` as an opaque display label — never a real URL.
+      endpoint: `local-script:${t.scriptPath}`,
+      mode: t.stateful === false ? "stateless" : "stateful",
+      promptPath: t.promptPath,
+      responsePath: t.responsePath,
+      sessionField: t.sessionIdField,
+      session: t.session,
+      model: t.model,
+    };
   }
   if (!t.endpoint) throw new Error("target is missing `endpoint`.");
   return {
@@ -217,8 +230,10 @@ export function registerHuntCommand(program: Command): void {
         loadDotenv({ path: path.resolve(opts.env), override: true });
       }
 
-      // If --ui is set and endpoint is missing, launch setup UI
-      if (opts.ui && !opts.endpoint) {
+      // If --ui is set and no target was given at all (neither --endpoint nor
+      // --target-config, e.g. a local-script target), launch the setup wizard.
+      // Otherwise --ui means the live dashboard for the already-configured target.
+      if (opts.ui && !opts.endpoint && !opts.targetConfig) {
         const brainAuth = resolveBrainAuth();
         if (!brainAuth) {
           consola.error(NO_BRAIN_AUTH_MESSAGE);
@@ -349,12 +364,25 @@ export function registerHuntCommand(program: Command): void {
         session: opts.sessionField ? undefined : baseTarget.session,
         model: opts.targetModel ?? baseTarget.model,
       };
-      if (!target.endpoint) {
+      if (target.type === "local-script") {
+        if (!target.scriptPath) {
+          consola.error(
+            "No scriptPath: set `scriptPath` on the local-script target in --target-config."
+          );
+          process.exitCode = 1;
+          return;
+        }
+      } else if (!target.endpoint) {
         consola.error("No endpoint: set --endpoint or an `endpoint` in --target-config.");
         process.exitCode = 1;
         return;
       }
-      if (!target.name) target.name = new URL(target.endpoint).host;
+      if (!target.name) {
+        target.name =
+          target.type === "local-script"
+            ? path.basename(target.scriptPath!)
+            : new URL(target.endpoint).host;
+      }
 
       if (target.mode === "stateful" && !target.sessionField && !target.session) {
         consola.warn(


### PR DESCRIPTION
## Problem

`opfor hunt` (the autonomous commander/operator/scout red-teaming mode) only supported HTTP targets. If a target's chat API couldn't be modeled as a simple request/response HTTP call — e.g. async/polling APIs, session ids embedded in a URL path segment rather than a body/header field (which `session.send` has no way to express), or auth flows needing custom logic — there was no way to point `opfor hunt` at it. `opfor run` already supported `type: "local-script"` targets for exactly this case; `opfor hunt` explicitly threw `"local-script targets are not supported by opfor hunt (HTTP only)."`.

Separately, `--ui` had a bug: it fell back to launching the setup wizard whenever `--endpoint` was omitted, even when a valid target was already supplied via `--target-config` (which is how local-script targets are configured, since they have no `endpoint`).

## Solution

- Added a `TargetKind` (`"http" | "local-script"`) to the autonomous runner's `TargetConfig`, plus a `scriptPath` field.
- Added `createLocalScriptTargetClient()`, a `TargetClient` implementation that shells out to a user script per turn (via the same `invokeLocalTargetScript` stdin/stdout contract `opfor run` already uses) instead of making an HTTP request. Hunt's per-thread `threadId` is passed through as the script's `sessionId`, so thread forks each get isolated sessions automatically — no extra wiring needed.
- `createTargetClient()` now branches on `config.type` to pick the HTTP or local-script client.
- Removed the hard `throw` in `mapAgentTargetToAutonomous()` and added proper mapping, validation (checks `scriptPath` instead of `endpoint`), and name-fallback (script basename instead of URL host) for local-script targets.
- Fixed `--ui`'s fallback condition to also check `!opts.targetConfig`, so it only launches the setup wizard when no target was specified at all.
- Bumped the local-script kill timeout from 30s to 240s (slow/polling-based target scripts were getting killed mid-turn).
- Fixed local-script error responses not being prefixed with `"ERROR:"`, which meant `isTargetError()` never actually flagged them as errors (it checks `response.startsWith("ERROR:")`) — errors from a script were silently treated as normal target replies.

## Changes

- `core/src/autonomous/lib/types.ts` — `TargetKind` type, `type`/`scriptPath` fields on `TargetConfig`
- `core/src/autonomous/target/http.ts` — branch to `createLocalScriptTargetClient()` in `createTargetClient()`
- `core/src/autonomous/target/localScript.ts` (new) — local-script `TargetClient` implementation
- `core/src/lib/localScriptTarget.ts` — timeout 30s → 240s; error responses now prefixed `ERROR:`
- `runners/cli/src/commands/hunt.ts` — local-script mapping/validation/naming in `mapAgentTargetToAutonomous()`; `--ui` fallback condition fix

## Issue

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for local-script targets in `opfor hunt`.
  * Local scripts now receive prompts and per-thread session IDs.
  * Configured targets can launch directly into the live dashboard with `--ui`.
  * Local target scripts support responses up to four minutes.

* **Bug Fixes**
  * Improved local-script validation, naming, error reporting, and rate-limit handling.

* **Documentation**
  * Added configuration examples and usage guidance for local-script targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->