### PR TITLE
fix(extension): show Base URL before API Key for custom provider

### DIFF
--- a/runners/extension/manifest.json
+++ b/runners/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Agent OPFOR",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Red-team any chat interface. Auto-detects chat widgets, runs adaptive attacks, and generates security reports.",
   "icons": {
     "16": "icons/icon16.png",

--- a/runners/extension/popup.html
+++ b/runners/extension/popup.html
@@ -2184,6 +2184,39 @@
               </div>
             </div>
 
+            <!-- Base URL (Azure + OpenAI-compatible only) -->
+            <div class="llm-field" id="baseUrlField" style="display: none">
+              <div class="endpoint-step-label">
+                Base URL
+                <span
+                  class="info-tip"
+                  data-tooltip="Root URL of your OpenAI-compatible server, e.g. http://localhost:11434/v1"
+                >
+                  <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <line x1="12" y1="8" x2="12" y2="12" />
+                    <line x1="12" y1="16" x2="12.01" y2="16" />
+                  </svg>
+                </span>
+              </div>
+              <input
+                id="baseUrl"
+                type="text"
+                placeholder="https://api.openai.com/v1"
+                autocomplete="off"
+                spellcheck="false"
+              />
+            </div>
+
             <!-- API Key -->
             <div class="llm-field">
               <div class="endpoint-step-label">
@@ -2235,39 +2268,6 @@
                   </svg>
                 </button>
               </div>
-            </div>
-
-            <!-- Base URL (Azure + OpenAI-compatible only) -->
-            <div class="llm-field" id="baseUrlField" style="display: none">
-              <div class="endpoint-step-label">
-                Base URL
-                <span
-                  class="info-tip"
-                  data-tooltip="Root URL of your OpenAI-compatible server, e.g. http://localhost:11434/v1"
-                >
-                  <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <circle cx="12" cy="12" r="10" />
-                    <line x1="12" y1="8" x2="12" y2="12" />
-                    <line x1="12" y1="16" x2="12.01" y2="16" />
-                  </svg>
-                </span>
-              </div>
-              <input
-                id="baseUrl"
-                type="text"
-                placeholder="https://api.openai.com/v1"
-                autocomplete="off"
-                spellcheck="false"
-              />
             </div>
             <!-- Model -->
             <div id="modelSection" class="llm-field">

--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -2733,7 +2733,7 @@ function applyProvider({ resetModel = false } = {}) {
   const isSimple = !!SIMPLE_PROVIDER_FETCH_CONFIG[state.provider];
 
   // Unified layout: every provider renders the same labeled rows
-  // (Provider → API Key → Base URL → Model). Only the Base URL row and the
+  // (Provider → Base URL → API Key → Model). Only the Base URL row and the
   // OpenAI-compatible affordances (optional-key note, model refresh) toggle.
   $("baseUrlField").style.display = needsBaseUrl ? "" : "none";
   $("apiKeyHint").style.display = isCompatible ? "inline-flex" : "none";


### PR DESCRIPTION
## Problem

In the extension popup, when **Custom (OpenAI-compatible)** or **Azure** is selected, **API Key** appeared before **Base URL**. That order is awkward for custom endpoints — users typically set the server URL first, then optionally add a key.


## Solution

Reordered the model selection fields so **Base URL** comes before **API Key** for providers that require a base URL. 

## Changes

**Extension UI**
- `runners/extension/popup.html` — moved Base URL field above API Key
- `runners/extension/popup.js` — updated layout comment to match new field order


## Issue

N/A



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Reordered the Base URL field in the provider configuration for a clearer setup flow.
* **Release**
  * Updated the extension version to 0.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->