### PR TITLE
feat: unify hunt cli report artifacts into one folder, add graceful Ctrl+C cancellation

### DIFF
--- a/core/src/autonomous/index.ts
+++ b/core/src/autonomous/index.ts
@@ -18,7 +18,7 @@ export type { BudgetGuardOptions } from "./lib/budget.js";
 export type { AutonomousReport } from "./report/types.js";
 export { mapRunLogToReport } from "./report/mapRunLog.js";
 export { renderReportHtml } from "./report/html.js";
-export { writeAutonomousReport } from "./report/writeReport.js";
+export { writeAutonomousReport, reportDirFor } from "./report/writeReport.js";
 
 export { loadKnowledge } from "./knowledge/load.js";
 export type {

--- a/core/src/autonomous/orchestrator/run.ts
+++ b/core/src/autonomous/orchestrator/run.ts
@@ -64,11 +64,7 @@ export interface RunHooks {
   progress?: ProgressReporter;
   /** Called once the in-memory RunLog is created — used by the live UI for snapshots. */
   onRunLog?: (runLog: import("../state/runLog.js").RunLog) => void;
-  /**
-   * Cancellation signal. When aborted the run interrupts the agent, keeps every
-   * finding gathered so far, and finalizes a partial (truncated) report instead of
-   * throwing. Callers (CLI) wire this to SIGINT / Ctrl+C.
-   */
+  /** Abort to stop the run early and finalize a partial (truncated) report instead of throwing. */
   signal?: AbortSignal;
 }
 
@@ -88,10 +84,8 @@ export async function runAutonomous(
     );
   }
 
-  // Handed off via `onRunLog` so callers can react — e.g. create the report folder and open
-  // live-log files inside it — before any progress event has a chance to fire. Deliberately
-  // created only after the checks above: a bad config (missing seed dir) should fail with zero
-  // artifacts on disk, not leave behind an empty report folder.
+  // Created only after the checks above — a bad config should fail with zero artifacts, not an
+  // empty report folder. Handed off via `onRunLog` before any progress event can fire.
   const runLog = createRunLog({
     runId: randomUUID(),
     objective: options.objective,
@@ -190,11 +184,8 @@ export async function runAutonomous(
 
   reporter?.onLine("Autonomous assessment started — commander initializing…");
 
-  // Cancellation: interrupt the SDK query the moment the caller aborts, rather than waiting
-  // for the next stream message. An in-flight operator attack (a long multi-turn exchange
-  // with the target) could otherwise keep the run alive for many seconds after Ctrl+C — the
-  // loop only regains control between messages. The truncation flags are set from the loop /
-  // catch below; here we just stop the agent promptly. `interrupt` is idempotent and guarded.
+  // Interrupt immediately so an in-flight multi-turn attack doesn't keep the run alive after
+  // Ctrl+C — truncation flags are set below, this just stops the agent promptly.
   const onAbort = (): void => {
     reporter?.onLine("⏹  interrupt received — stopping agents, finalizing a partial report…");
     void q.interrupt().catch(() => {});
@@ -289,11 +280,8 @@ export async function runAutonomous(
       }
     }
   } catch (err) {
-    // A mid-run failure (e.g. provider usage-policy block, network error) — or the SDK
-    // child being torn down by the same Ctrl+C the caller aborted on — must NOT lose the
-    // findings already captured in the RunLog. Mark the run truncated and fall through to
-    // build a partial report. When the user aborted, prefer the friendly interrupt reason
-    // over the raw SDK error.
+    // A mid-run failure or the abort itself must not lose captured findings — mark truncated
+    // and fall through to a partial report.
     const message = err instanceof Error ? err.message : String(err);
     runLog.truncated = true;
     if (signal?.aborted) {

--- a/core/src/autonomous/orchestrator/run.ts
+++ b/core/src/autonomous/orchestrator/run.ts
@@ -64,7 +64,16 @@ export interface RunHooks {
   progress?: ProgressReporter;
   /** Called once the in-memory RunLog is created — used by the live UI for snapshots. */
   onRunLog?: (runLog: import("../state/runLog.js").RunLog) => void;
+  /**
+   * Cancellation signal. When aborted the run interrupts the agent, keeps every
+   * finding gathered so far, and finalizes a partial (truncated) report instead of
+   * throwing. Callers (CLI) wire this to SIGINT / Ctrl+C.
+   */
+  signal?: AbortSignal;
 }
+
+/** Truncation reason recorded when a run is stopped by the user rather than a ceiling/error. */
+const USER_INTERRUPT_REASON = "interrupted by user (Ctrl+C)";
 
 export async function runAutonomous(
   options: HuntOptions,
@@ -79,6 +88,10 @@ export async function runAutonomous(
     );
   }
 
+  // Handed off via `onRunLog` so callers can react — e.g. create the report folder and open
+  // live-log files inside it — before any progress event has a chance to fire. Deliberately
+  // created only after the checks above: a bad config (missing seed dir) should fail with zero
+  // artifacts on disk, not leave behind an empty report folder.
   const runLog = createRunLog({
     runId: randomUUID(),
     objective: options.objective,
@@ -173,14 +186,38 @@ export async function runAutonomous(
 
   const q = query({ prompt: kickoff, options: queryOptions });
   const reporter = runHooks?.progress;
+  const signal = runHooks?.signal;
 
   reporter?.onLine("Autonomous assessment started — commander initializing…");
+
+  // Cancellation: interrupt the SDK query the moment the caller aborts, rather than waiting
+  // for the next stream message. An in-flight operator attack (a long multi-turn exchange
+  // with the target) could otherwise keep the run alive for many seconds after Ctrl+C — the
+  // loop only regains control between messages. The truncation flags are set from the loop /
+  // catch below; here we just stop the agent promptly. `interrupt` is idempotent and guarded.
+  const onAbort = (): void => {
+    reporter?.onLine("⏹  interrupt received — stopping agents, finalizing a partial report…");
+    void q.interrupt().catch(() => {});
+  };
+  if (signal) {
+    if (signal.aborted) onAbort();
+    else signal.addEventListener("abort", onAbort, { once: true });
+  }
 
   // Tracks last reported cost threshold so we only emit a cost line every $0.10.
   let lastReportedCostUsd = 0;
 
   try {
     for await (const message of q) {
+      // Stop promptly on cancellation while messages are still flowing (the abort listener
+      // above covers the idle-between-messages case).
+      if (signal?.aborted && !runLog.completed) {
+        runLog.truncated = true;
+        if (!runLog.truncationReason) runLog.truncationReason = USER_INTERRUPT_REASON;
+        await q.interrupt().catch(() => {});
+        break;
+      }
+
       if (message.type === "assistant") {
         const text = message.message.content
           .map((b) => (b.type === "text" ? b.text : ""))
@@ -252,18 +289,35 @@ export async function runAutonomous(
       }
     }
   } catch (err) {
-    // A mid-run failure (e.g. provider usage-policy block, network error) must
-    // NOT lose the findings already captured in the RunLog. Mark the run
-    // truncated and fall through to build a partial report.
+    // A mid-run failure (e.g. provider usage-policy block, network error) — or the SDK
+    // child being torn down by the same Ctrl+C the caller aborted on — must NOT lose the
+    // findings already captured in the RunLog. Mark the run truncated and fall through to
+    // build a partial report. When the user aborted, prefer the friendly interrupt reason
+    // over the raw SDK error.
     const message = err instanceof Error ? err.message : String(err);
     runLog.truncated = true;
-    runLog.truncationReason = `run interrupted: ${message.slice(0, 300)}`;
-    reporter?.onLine(
-      `⚠️  run interrupted — finalizing partial report from ${runLog.findings.length} finding(s)`
-    );
-    reporter?.onLine(`    reason: ${message.slice(0, 200)}`);
+    if (signal?.aborted) {
+      runLog.truncationReason = USER_INTERRUPT_REASON;
+      reporter?.onLine(
+        `⏹  run interrupted — finalizing partial report from ${runLog.findings.length} finding(s)`
+      );
+    } else {
+      runLog.truncationReason = `run interrupted: ${message.slice(0, 300)}`;
+      reporter?.onLine(
+        `⚠️  run interrupted — finalizing partial report from ${runLog.findings.length} finding(s)`
+      );
+      reporter?.onLine(`    reason: ${message.slice(0, 200)}`);
+    }
   } finally {
+    if (signal) signal.removeEventListener("abort", onAbort);
     q.close();
+  }
+
+  // Safety net: if the caller aborted but neither the loop nor the catch labelled it (e.g. the
+  // stream ended cleanly right as the interrupt landed), still mark it a user interrupt.
+  if (signal?.aborted && !runLog.completed && !runLog.truncated) {
+    runLog.truncated = true;
+    runLog.truncationReason = USER_INTERRUPT_REASON;
   }
 
   if (!runLog.completed && !runLog.truncated) {

--- a/core/src/autonomous/report/mapRunLog.ts
+++ b/core/src/autonomous/report/mapRunLog.ts
@@ -191,6 +191,7 @@ export function mapRunLogToReport(log: RunLog): AutonomousReport {
 
   return {
     reportId: log.runId,
+    startedAt: log.startedAt,
     generatedAt: new Date().toISOString(),
     target: { name: log.targetName, endpoint: log.targetEndpoint },
     objective: log.objective,

--- a/core/src/autonomous/report/types.ts
+++ b/core/src/autonomous/report/types.ts
@@ -85,6 +85,7 @@ export interface PersonaTimelineEntry {
 
 export interface AutonomousReport {
   reportId: string;
+  startedAt: string;
   generatedAt: string;
   target: { name: string; endpoint: string };
   objective: string;

--- a/core/src/autonomous/report/writeReport.ts
+++ b/core/src/autonomous/report/writeReport.ts
@@ -21,12 +21,7 @@ function slugify(name: string): string {
   );
 }
 
-/**
- * The report subfolder name is derived entirely from values known at run start (target name,
- * run id, start time) — not from anything only available once the run finishes. That lets
- * callers create this folder up front and write live logs directly into it, instead of writing
- * elsewhere and relocating them once the report exists.
- */
+/** Report folder name — derivable at run start, so callers can create it upfront instead of relocating files later. */
 export function reportDirFor(
   outputDir: string,
   params: { targetName: string; runId: string; startedAt: string }

--- a/core/src/autonomous/report/writeReport.ts
+++ b/core/src/autonomous/report/writeReport.ts
@@ -11,21 +11,44 @@ export interface ReportFiles {
   dir: string;
 }
 
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 40) || "target"
+  );
+}
+
+/**
+ * The report subfolder name is derived entirely from values known at run start (target name,
+ * run id, start time) — not from anything only available once the run finishes. That lets
+ * callers create this folder up front and write live logs directly into it, instead of writing
+ * elsewhere and relocating them once the report exists.
+ */
+export function reportDirFor(
+  outputDir: string,
+  params: { targetName: string; runId: string; startedAt: string }
+): string {
+  const compactTs = params.startedAt.replace(/[-:T.Z]/g, "").slice(0, 14);
+  const slug = slugify(params.targetName);
+  const shortId = params.runId.replace(/-/g, "").slice(0, 8);
+  return path.resolve(outputDir, `hunt-report-${compactTs}-${slug}-${shortId}`);
+}
+
 export async function writeAutonomousReport(
   report: AutonomousReport,
   outputDir: string
 ): Promise<ReportFiles> {
-  const compactTs = report.generatedAt.replace(/[-:T.Z]/g, "").slice(0, 14);
-  const slug =
-    report.target.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "")
-      .slice(0, 40) || "target";
-  const shortId = report.reportId.replace(/-/g, "").slice(0, 8);
-  const dir = path.resolve(outputDir, `hunt-report-${compactTs}-${slug}-${shortId}`);
+  const dir = reportDirFor(outputDir, {
+    targetName: report.target.name,
+    runId: report.reportId,
+    startedAt: report.startedAt,
+  });
   await mkdir(dir, { recursive: true });
 
+  const slug = slugify(report.target.name);
   const htmlPath = path.join(dir, `${slug}-report.html`);
   const jsonPath = path.join(dir, `${slug}-report.json`);
 

--- a/docs/hunt.md
+++ b/docs/hunt.md
@@ -132,6 +132,14 @@ respond before it's killed.
 | `--ui`             | Launch live dashboard |
 | `--ui-port <port>` | `3847`                |
 
+Each run writes everything into one folder — `hunt-report-<timestamp>-<target>-<id>/` — containing the live log (`hunt-live.log`), the structured event trail (`run-events.jsonl`), and the final `*-report.html` / `*-report.json`.
+
+## Stopping a run
+
+Press **Ctrl+C** once to stop early: the agent is interrupted, and a report is still written from the findings gathered so far (with the live log and event trail already on disk). The report is marked as truncated so it's clear the assessment was cut short. Press **Ctrl+C** a second time to force-quit without writing a report.
+
+The same applies if a run errors out mid-flight (provider block, network failure) — findings captured up to that point are preserved in a partial report rather than lost.
+
 ## Authentication
 
 Credentials are resolved in order:

--- a/runners/cli/src/commands/hunt.ts
+++ b/runners/cli/src/commands/hunt.ts
@@ -298,10 +298,8 @@ export function registerHuntCommand(program: Command): void {
           },
         });
 
-        // Graceful shutdown for the browser-launched assessment. First Ctrl+C aborts a
-        // running assessment so it finalizes a partial report (onComplete → cleanup); if
-        // nothing is running yet (still on the setup form) we just exit. Second Ctrl+C
-        // force-quits.
+        // First Ctrl+C aborts a running assessment (partial report via onComplete), or exits if
+        // idle on the setup form; second Ctrl+C force-quits.
         let setupSigintCount = 0;
         const onSetupSigint = (): void => {
           setupSigintCount++;
@@ -456,10 +454,7 @@ export function registerHuntCommand(program: Command): void {
       ].join("\n");
       process.stdout.write(header + "\n");
 
-      // Report folder + live-log files are created from `onRunLog` below, as soon as the
-      // orchestrator hands back the RunLog (runId/startedAt/targetName are all it takes to name
-      // the folder — see `reportDirFor`). That fires before any progress event, so by the time
-      // `emit`/`emitEvent` are ever called the streams already exist.
+      // Folder + streams are created from `onRunLog` below, before any progress event can fire.
       let reportDir = "";
       let liveLogPath = "";
       let eventLogPath = "";
@@ -520,9 +515,7 @@ export function registerHuntCommand(program: Command): void {
       const fileReporter = { onLine: emit, onEvent: emitEvent };
       const progress = uiHandle ? mergeReporters(fileReporter, uiHandle.bridge) : fileReporter;
 
-      // Graceful shutdown: first Ctrl+C aborts so the commander stops dispatching, the
-      // in-flight agent turn is interrupted, and we still write a report from whatever was
-      // found up to that point (plus the live logs already on disk). Second Ctrl+C force-quits.
+      // First Ctrl+C aborts and finalizes a partial report; second Ctrl+C force-quits.
       const ac = new AbortController();
       let sigintCount = 0;
       const onSigint = (): void => {

--- a/runners/cli/src/commands/hunt.ts
+++ b/runners/cli/src/commands/hunt.ts
@@ -1,7 +1,7 @@
 import type { Command } from "commander";
 import path from "node:path";
-import { readFile, mkdir } from "node:fs/promises";
-import { createWriteStream, existsSync, type WriteStream } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { createWriteStream, existsSync, mkdirSync, type WriteStream } from "node:fs";
 import { homedir } from "node:os";
 import { consola } from "consola";
 import type {
@@ -11,7 +11,10 @@ import type {
 import type { RunEvent } from "@keyvaluesystems/agent-opfor-core/autonomous/state/observe.js";
 import { parseAgentTarget } from "@keyvaluesystems/agent-opfor-core/config/schema.js";
 import { runAutonomous } from "@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/run.js";
-import { writeAutonomousReport } from "@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js";
+import {
+  writeAutonomousReport,
+  reportDirFor,
+} from "@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js";
 import { startUiServer } from "../ui/server.js";
 import { mergeReporters } from "../ui/bridge.js";
 
@@ -295,6 +298,27 @@ export function registerHuntCommand(program: Command): void {
           },
         });
 
+        // Graceful shutdown for the browser-launched assessment. First Ctrl+C aborts a
+        // running assessment so it finalizes a partial report (onComplete → cleanup); if
+        // nothing is running yet (still on the setup form) we just exit. Second Ctrl+C
+        // force-quits.
+        let setupSigintCount = 0;
+        const onSetupSigint = (): void => {
+          setupSigintCount++;
+          if (setupSigintCount >= 2) {
+            void cleanup(130);
+            return;
+          }
+          if (serverHandle?.abortAssessment()) {
+            consola.warn(
+              "\nCaught interrupt — finalizing a partial report… (Ctrl+C again to force quit)"
+            );
+          } else {
+            void cleanup(0);
+          }
+        };
+        process.on("SIGINT", onSetupSigint);
+
         // Keep process alive until onComplete is called
         await new Promise(() => {});
         return;
@@ -420,25 +444,38 @@ export function registerHuntCommand(program: Command): void {
         outputDir: path.resolve(opts.output),
       };
 
-      // Live log file the user can `tail -f` while the run is in progress.
-      await mkdir(huntOptions.outputDir, { recursive: true });
-      const startedAt = new Date()
-        .toISOString()
-        .replace(/[-:T.Z]/g, "")
-        .slice(0, 14);
-      const liveLogPath = path.join(huntOptions.outputDir, `hunt-live-${startedAt}.log`);
-      const liveLog: WriteStream = createWriteStream(liveLogPath, { flags: "a" });
+      const header = [
+        "════════════════════════════════════════════════════════════════",
+        ` AUTONOMOUS RED-TEAM`,
+        ` target    : ${target.name} (${target.mode})  ${target.endpoint}`,
+        ` objective : ${objective}`,
+        ` models    : commander=${huntOptions.commanderModel}  operator=${huntOptions.operatorModel}  scout=${huntOptions.scoutModel}`,
+        ` limits    : operators≤${huntOptions.maxOperators}  turns≤${huntOptions.maxTurns}  thread-turns≤${huntOptions.maxThreadTurns}${huntOptions.budgetUsd ? `  budget=$${huntOptions.budgetUsd}` : ""}`,
+        ` verifier  : ${huntOptions.verify ? "on" : "off"}`,
+        "════════════════════════════════════════════════════════════════",
+      ].join("\n");
+      process.stdout.write(header + "\n");
+
+      // Report folder + live-log files are created from `onRunLog` below, as soon as the
+      // orchestrator hands back the RunLog (runId/startedAt/targetName are all it takes to name
+      // the folder — see `reportDirFor`). That fires before any progress event, so by the time
+      // `emit`/`emitEvent` are ever called the streams already exist.
+      let reportDir = "";
+      let liveLogPath = "";
+      let eventLogPath = "";
+      let liveLog: WriteStream | undefined;
+      let eventLog: WriteStream | undefined;
+
       const emit = (line: string): void => {
         const stamped = `[${clock()}] ${line}`;
         process.stdout.write(stamped + "\n");
-        liveLog.write(stamped + "\n");
+        liveLog?.write(stamped + "\n");
       };
 
       // Structured event trail (one JSON object per line) — machine-readable for debugging and
       // the foundation a future "opfor view" web UI consumes. Stamped with a wall-clock time.
-      const eventLogPath = path.join(huntOptions.outputDir, `run-${startedAt}.jsonl`);
-      const eventLog: WriteStream = createWriteStream(eventLogPath, { flags: "a" });
       const emitEvent = (event: RunEvent): void => {
+        if (!eventLog) return;
         // An observability sink must never crash the run. Guard JSON.stringify (data is
         // Record<string, unknown> — a future event could carry a circular ref / BigInt).
         try {
@@ -454,20 +491,6 @@ export function registerHuntCommand(program: Command): void {
           );
         }
       };
-
-      const header = [
-        "════════════════════════════════════════════════════════════════",
-        ` AUTONOMOUS RED-TEAM`,
-        ` target    : ${target.name} (${target.mode})  ${target.endpoint}`,
-        ` objective : ${objective}`,
-        ` models    : commander=${huntOptions.commanderModel}  operator=${huntOptions.operatorModel}  scout=${huntOptions.scoutModel}`,
-        ` limits    : operators≤${huntOptions.maxOperators}  turns≤${huntOptions.maxTurns}  thread-turns≤${huntOptions.maxThreadTurns}${huntOptions.budgetUsd ? `  budget=$${huntOptions.budgetUsd}` : ""}`,
-        ` verifier  : ${huntOptions.verify ? "on" : "off"}`,
-        "════════════════════════════════════════════════════════════════",
-      ].join("\n");
-      process.stdout.write(header + "\n");
-      liveLog.write(header + "\n");
-      consola.box(`Live log (tail it):\n  tail -f ${liveLogPath}`);
 
       let uiHandle: Awaited<ReturnType<typeof startUiServer>> | undefined;
       if (opts.ui) {
@@ -490,8 +513,6 @@ export function registerHuntCommand(program: Command): void {
         } catch (err) {
           consola.error(`Failed to start UI server: ${String(err)}`);
           process.exitCode = 1;
-          liveLog.end();
-          eventLog.end();
           return;
         }
       }
@@ -499,32 +520,74 @@ export function registerHuntCommand(program: Command): void {
       const fileReporter = { onLine: emit, onEvent: emitEvent };
       const progress = uiHandle ? mergeReporters(fileReporter, uiHandle.bridge) : fileReporter;
 
+      // Graceful shutdown: first Ctrl+C aborts so the commander stops dispatching, the
+      // in-flight agent turn is interrupted, and we still write a report from whatever was
+      // found up to that point (plus the live logs already on disk). Second Ctrl+C force-quits.
+      const ac = new AbortController();
+      let sigintCount = 0;
+      const onSigint = (): void => {
+        sigintCount++;
+        if (sigintCount === 1) {
+          consola.warn("\nCaught interrupt — stopping agents and finalizing a partial report…");
+          consola.warn("Press Ctrl+C again to force quit (no report will be written).\n");
+          ac.abort();
+        } else {
+          process.exit(130);
+        }
+      };
+      process.on("SIGINT", onSigint);
+
       let report;
       try {
         report = await runAutonomous(huntOptions, {
           progress,
-          onRunLog: uiHandle ? (log) => uiHandle!.attachRunLog(log) : undefined,
+          signal: ac.signal,
+          onRunLog: (log) => {
+            reportDir = reportDirFor(huntOptions.outputDir, {
+              targetName: log.targetName,
+              runId: log.runId,
+              startedAt: log.startedAt,
+            });
+            mkdirSync(reportDir, { recursive: true });
+            liveLogPath = path.join(reportDir, "hunt-live.log");
+            eventLogPath = path.join(reportDir, "run-events.jsonl");
+            liveLog = createWriteStream(liveLogPath, { flags: "a" });
+            eventLog = createWriteStream(eventLogPath, { flags: "a" });
+            liveLog.write(header + "\n");
+            consola.box(`Live log (tail it):\n  tail -f ${liveLogPath}`);
+            uiHandle?.attachRunLog(log);
+          },
         });
       } finally {
-        liveLog.end();
-        eventLog.end();
+        // Stop intercepting SIGINT before the post-run UI wait installs its own handler.
+        process.off("SIGINT", onSigint);
+        liveLog?.end();
+        eventLog?.end();
       }
+
+      const interrupted = ac.signal.aborted;
 
       const { html, json, dir } = await writeAutonomousReport(report, huntOptions.outputDir);
 
       uiHandle?.markComplete({ reportDir: dir, outcome: report.objectiveOutcome });
 
       consola.info("");
-      consola.success(`Assessment complete — outcome: ${report.objectiveOutcome}`);
+      if (interrupted) {
+        consola.warn(`Assessment interrupted — partial report written from work completed so far.`);
+      } else {
+        consola.success(`Assessment complete — outcome: ${report.objectiveOutcome}`);
+      }
       consola.info(
         `Vulnerabilities: ${report.summary.confirmed} · Defended: ${report.summary.defended} · Errors: ${report.summary.errors}`
       );
       if (report.totalCostUsd !== undefined)
         consola.info(`Cost: $${report.totalCostUsd.toFixed(4)}`);
-      if (report.truncated) consola.warn(`Run truncated: ${report.truncationReason}`);
+      if (report.truncated && !interrupted)
+        consola.warn(`Run truncated: ${report.truncationReason}`);
       consola.success(`Report: ${html}`);
       consola.info(`   JSON: ${json}`);
       consola.info(`   Dir : ${dir}`);
+      consola.info(`   Live log: ${liveLogPath}`);
       consola.info(`   Events: ${eventLogPath}`);
       if (uiHandle) {
         consola.info(`   UI    : ${uiHandle.url} (press Ctrl+C to exit)`);

--- a/runners/cli/src/commands/hunt.ts
+++ b/runners/cli/src/commands/hunt.ts
@@ -562,7 +562,13 @@ export function registerHuntCommand(program: Command): void {
 
       const { html, json, dir } = await writeAutonomousReport(report, huntOptions.outputDir);
 
-      uiHandle?.markComplete({ reportDir: dir, outcome: report.objectiveOutcome });
+      // `outcome` is the dashboard's final status label (rendered verbatim). On interrupt show
+      // "interrupted" so a cancelled run isn't mistaken for a normal finish; otherwise show the
+      // assessment verdict, which is more useful than a generic "completed".
+      uiHandle?.markComplete({
+        reportDir: dir,
+        outcome: interrupted ? "interrupted" : report.objectiveOutcome,
+      });
 
       consola.info("");
       if (interrupted) {

--- a/runners/cli/src/commands/setup.ts
+++ b/runners/cli/src/commands/setup.ts
@@ -48,6 +48,7 @@ export async function runSetupAndWrite(opts?: {
   await writeFile(outPath, JSON.stringify(config, null, 2), "utf8");
 
   log.success(`\nConfig written → ${outPath}`);
+  log.info(`Made a mistake? Edit any field in that JSON file directly before running it.`);
   return { config, path: outPath };
 }
 

--- a/runners/cli/src/ui/server.ts
+++ b/runners/cli/src/ui/server.ts
@@ -2,9 +2,7 @@
 
 import http from "node:http";
 import path from "node:path";
-import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
-import { createWriteStream, type WriteStream } from "node:fs";
+import { existsSync, createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { exec } from "node:child_process";
 import express from "express";
@@ -77,6 +75,11 @@ export interface UiServerHandle {
   url: string;
   attachRunLog: (runLog: RunLog) => void;
   markComplete: (payload: { reportDir?: string; outcome?: string }) => void;
+  /**
+   * Abort an in-progress setup-mode assessment so it finalizes a partial report.
+   * Returns true if a run was actually in progress, false if idle (nothing to abort).
+   */
+  abortAssessment: () => boolean;
   close: () => Promise<void>;
 }
 
@@ -109,6 +112,10 @@ function openInBrowser(url: string): void {
 export async function startUiServer(options: UiServerOptions): Promise<UiServerHandle> {
   const app = express();
   const bridge = new UiBridge();
+
+  // Cancellation for a setup-mode assessment. Created fresh per run in the /api/start handler;
+  // aborting it lets the in-flight run finalize a partial report instead of dying mid-attack.
+  let assessmentAbort: AbortController | undefined;
   bridge.setMeta(options.meta);
   const staticDir = resolveStaticDir();
 
@@ -260,8 +267,10 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 
       res.json({ ok: true, message: "Assessment started" });
 
+      assessmentAbort = new AbortController();
+
       // Run the assessment in-process (async, don't await in handler)
-      runAssessmentInProcess(autoOptions, bridge, options.onLog)
+      runAssessmentInProcess(autoOptions, bridge, options.onLog, assessmentAbort.signal)
         .then((reportDir) => {
           options.onComplete?.({ success: true, reportDir });
         })
@@ -274,6 +283,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
         })
         .finally(() => {
           runningAssessment = false;
+          assessmentAbort = undefined;
         });
     });
   }
@@ -310,6 +320,11 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
     markComplete(payload) {
       bridge.markComplete(payload);
     },
+    abortAssessment() {
+      if (!assessmentAbort) return false;
+      assessmentAbort.abort();
+      return true;
+    },
     close() {
       return new Promise((resolve, reject) => {
         server.close((err) => (err ? reject(err) : resolve()));
@@ -322,35 +337,33 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
 async function runAssessmentInProcess(
   autoOptions: HuntOptions,
   bridge: UiBridge,
-  onLog?: (line: string) => void
+  onLog?: (line: string) => void,
+  signal?: AbortSignal
 ): Promise<string | undefined> {
   const { runAutonomous } =
     await import("@keyvaluesystems/agent-opfor-core/autonomous/orchestrator/run.js");
-  const { writeAutonomousReport } =
+  const { writeAutonomousReport, reportDirFor } =
     await import("@keyvaluesystems/agent-opfor-core/autonomous/report/writeReport.js");
-
-  // Set up output directory and log files
-  await mkdir(autoOptions.outputDir, { recursive: true });
-  const startedAt = new Date()
-    .toISOString()
-    .replace(/[-:T.Z]/g, "")
-    .slice(0, 14);
-  const liveLogPath = path.join(autoOptions.outputDir, `hunt-live-${startedAt}.log`);
-  const liveLog: WriteStream = createWriteStream(liveLogPath, { flags: "a" });
-  const eventLogPath = path.join(autoOptions.outputDir, `run-${startedAt}.jsonl`);
-  const eventLog: WriteStream = createWriteStream(eventLogPath, { flags: "a" });
 
   const clock = () => new Date().toISOString().slice(11, 19);
 
+  // Report folder + live-log files are created from `onRunLog` below, as soon as the
+  // orchestrator hands back the RunLog (runId/startedAt/targetName are all it takes to name
+  // the folder — see `reportDirFor`). That fires before any progress event, so by the time
+  // `emit`/`emitEvent` are ever called the streams already exist.
+  let liveLog: WriteStream | undefined;
+  let eventLog: WriteStream | undefined;
+
   const emit = (line: string): void => {
     const stamped = `[${clock()}] ${line}`;
-    liveLog.write(stamped + "\n");
+    liveLog?.write(stamped + "\n");
     bridge.onLine(line);
     // Also stream to terminal
     onLog?.(stamped);
   };
 
   const emitEvent = (event: RunEvent): void => {
+    if (!eventLog) return;
     try {
       eventLog.write(JSON.stringify({ ...event, wall: clock() }) + "\n");
     } catch {
@@ -359,15 +372,25 @@ async function runAssessmentInProcess(
     bridge.onEvent(event);
   };
 
-  emit(`Starting autonomous assessment against ${autoOptions.target.name}`);
-  emit(`Objective: ${autoOptions.objective}`);
-
   let reportDir: string | undefined;
 
   try {
     const report = await runAutonomous(autoOptions, {
       progress: { onLine: emit, onEvent: emitEvent },
+      signal,
       onRunLog: (runLog) => {
+        reportDir = reportDirFor(autoOptions.outputDir, {
+          targetName: runLog.targetName,
+          runId: runLog.runId,
+          startedAt: runLog.startedAt,
+        });
+        mkdirSync(reportDir, { recursive: true });
+        liveLog = createWriteStream(path.join(reportDir, "hunt-live.log"), { flags: "a" });
+        eventLog = createWriteStream(path.join(reportDir, "run-events.jsonl"), { flags: "a" });
+
+        emit(`Starting autonomous assessment against ${autoOptions.target.name}`);
+        emit(`Objective: ${autoOptions.objective}`);
+
         bridge.attachRunLog(runLog, {
           objective: autoOptions.objective,
           targetName: autoOptions.target.name,
@@ -380,15 +403,18 @@ async function runAssessmentInProcess(
       },
     });
 
-    emit("Run completed, writing report…");
+    const interrupted = signal?.aborted ?? false;
+    emit(
+      interrupted ? "Run interrupted, writing partial report…" : "Run completed, writing report…"
+    );
     const reportFiles = await writeAutonomousReport(report, autoOptions.outputDir);
     reportDir = reportFiles.dir;
     emit(`Report written to ${reportDir}`);
 
-    bridge.markComplete({ reportDir, outcome: "completed" });
+    bridge.markComplete({ reportDir, outcome: interrupted ? "interrupted" : "completed" });
   } finally {
-    liveLog.end();
-    eventLog.end();
+    liveLog?.end();
+    eventLog?.end();
   }
 
   return reportDir;

--- a/runners/cli/src/ui/server.ts
+++ b/runners/cli/src/ui/server.ts
@@ -113,8 +113,7 @@ export async function startUiServer(options: UiServerOptions): Promise<UiServerH
   const app = express();
   const bridge = new UiBridge();
 
-  // Cancellation for a setup-mode assessment. Created fresh per run in the /api/start handler;
-  // aborting it lets the in-flight run finalize a partial report instead of dying mid-attack.
+  // Created fresh per run in the /api/start handler; aborting finalizes a partial report.
   let assessmentAbort: AbortController | undefined;
   bridge.setMeta(options.meta);
   const staticDir = resolveStaticDir();
@@ -347,10 +346,7 @@ async function runAssessmentInProcess(
 
   const clock = () => new Date().toISOString().slice(11, 19);
 
-  // Report folder + live-log files are created from `onRunLog` below, as soon as the
-  // orchestrator hands back the RunLog (runId/startedAt/targetName are all it takes to name
-  // the folder — see `reportDirFor`). That fires before any progress event, so by the time
-  // `emit`/`emitEvent` are ever called the streams already exist.
+  // Folder + streams are created from `onRunLog` below, before any progress event can fire.
   let liveLog: WriteStream | undefined;
   let eventLog: WriteStream | undefined;
 


### PR DESCRIPTION
## Problem

`opfor hunt` scattered a single run's output across two places: the live log (`hunt-live-<ts>.log`) and structured event trail (`run-<ts>.jsonl`) were written directly into `.opfor/reports/`, while the final `*-report.html`/`*-report.json` landed in their own `hunt-report-<ts>-<slug>-<id>/` subfolder — created only at the very end, since its name depended on values not known until the run finished. A single hunt's artifacts were never together in one place.

Separately, `opfor hunt` had no cancellation support at all. Ctrl+C during a run just killed the process — no partial report, no findings preserved, nothing usable from the run so far.

The SDK (`@keyvaluesystems/agent-opfor-sdk`) is unaffected by the folder issue — it never wrote log/jsonl files to disk in the first place (callers get the equivalent via `onProgress`), so this only touches the CLI's file-based output.

## Solution

**One folder per run.** The report folder's name (`hunt-report-<startedAt>-<slug>-<shortId>`) turned out to be fully determined by values available at run *start* (target name, run id, start time), not completion — they just weren't threaded through in time. Exposed a `reportDirFor()` helper in core and had the CLI create the folder immediately when the orchestrator hands back its `RunLog` (via the existing `onRunLog` hook), opening `hunt-live.log` and `run-events.jsonl` directly inside it from the first line. `writeAutonomousReport()` now reuses the same helper so the final `.html`/`.json` land in the exact same folder — no rename/move step needed. Also fixed an ordering issue this surfaced along the way: run-log creation is deliberately kept *after* the seed-knowledge validation check, so a bad `--seed-dir` config still fails with zero artifacts on disk, not an empty report folder.

**Graceful cancellation.** Added an `AbortSignal` to `runAutonomous()`'s hooks. First Ctrl+C aborts it, which interrupts the in-flight Claude Agent SDK query and lets the orchestrator finalize a partial, explicitly-truncated report from whatever findings were captured so far — with the live log/event trail already safely on disk. Second Ctrl+C force-quits with no report. Wired into both the plain CLI path and the `--ui` setup-mode path (new `abortAssessment()` on the UI server handle).

## Changes

**Core** (`@keyvaluesystems/agent-opfor-core`)
- `autonomous/report/writeReport.ts` — extracted `reportDirFor()`; `writeAutonomousReport()` now derives the folder from `report.startedAt` instead of `report.generatedAt`
- `autonomous/report/types.ts`, `autonomous/report/mapRunLog.ts` — `AutonomousReport` now carries `startedAt`
- `autonomous/orchestrator/run.ts` — `RunHooks.signal?: AbortSignal`; interrupts the SDK query on abort, marks the run truncated with a friendly reason, safety-net check at the end
- `autonomous/index.ts` — exports `reportDirFor`

**CLI** (`@keyvaluesystems/agent-opfor-cli`)
- `commands/hunt.ts` — creates the report folder + opens both log files from `onRunLog`; wires `AbortController` to SIGINT (first = graceful stop, second = force-quit); adjusts completion messaging for interrupted runs
- `ui/server.ts` — same folder/log-file change for the `--ui` in-process path; new `abortAssessment()` on `UiServerHandle`
- `commands/setup.ts` — minor UX hint (edit the generated config JSON directly)

**Docs**
- `docs/hunt.md` — documents the single-folder output layout and the new Ctrl+C behavior

## Issue

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stop hunts/assessments with Ctrl+C (including the setup UI) while preserving work in a partial, truncated report.
  - Reports now include a start-time field and write to deterministic, per-run output folders.
  - Completion output now distinguishes successful vs interrupted runs and surfaces event-log paths.
  - Setup generation adds a prompt to edit the generated JSON config before running.
- **Bug Fixes**
  - Strengthened abort/cancellation handling to reliably truncate reports and preserve logs/findings on user interrupts and mid-run errors.
- **Documentation**
  - Added “Stopping a run” guidance describing truncated report behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->