### PR TITLE
feat: add cancelled run state and fix extension pause/resume flow

### DIFF
--- a/runners/extension/domTarget.js
+++ b/runners/extension/domTarget.js
@@ -16,12 +16,15 @@ const MAX_CONSECUTIVE_FAILURES = 2;
  * readerCfg: LLM config for message shortening (reader model)
  * options:
  *   waitMs:      ms to wait between send and extract (default 5000)
+ *   roundOffset: rounds already completed before this adapter was created —
+ *                set on resume so reported round numbers continue from where
+ *                the paused run left off instead of restarting at 1
  *   onUserSent:  async ({ round, prompt }) => void — fires right after send, before extraction
  *   onTurnDone:  async ({ round, userMessage, sentOk, extractedOk, assistantPreview }) => void
  *   onRecovery:  async () => { plan, frameId }|null — called on consecutive DOM failures
  */
 export function createDomTarget(tabId, frameId, plan, readerCfg, options = {}) {
-  const { waitMs = 5000, onUserSent, onTurnDone, onRecovery } = options;
+  const { waitMs = 5000, roundOffset = 0, onUserSent, onTurnDone, onRecovery } = options;
 
   let currentPlan = plan;
   let currentFrameId = frameId;
@@ -72,7 +75,7 @@ export function createDomTarget(tabId, frameId, plan, readerCfg, options = {}) {
       }
       if (state.OPFOR_STOP) throw domTargetStopError();
 
-      const round = turns.length + 1;
+      const round = roundOffset + turns.length + 1;
 
       // Pre-send snapshot (used for diff extraction)
       const prevSnapshot = await snapshotCurrentResponse(tabId, currentFrameId);

--- a/runners/extension/orchestrator.js
+++ b/runners/extension/orchestrator.js
@@ -85,11 +85,18 @@ function cancelledJudgment(transcript) {
  *   cancel → a terminal CANCELLED result, and NO resumable snapshot (which
  *            would otherwise resurrect a "Run paused / Resume" screen).
  *
+ * Pass `canPause: false` when the run cannot be made resumable (no usable
+ * widget plan). A pause is then degraded to a cancel through the SAME branch,
+ * so it still clears any snapshot left by an earlier pause — that snapshot
+ * otherwise survives a resume (it is only dropped on success) and would
+ * resurrect a stale "Resume" screen for a run just recorded as cancelled.
+ *
  * Returns the response payload for the popup, with an explicit intent so the
  * popup never has to infer pause-vs-cancel from the ambiguous `paused` flag.
  */
-async function finalizeUserInterruption({ pauseSnapshot, cancelResult }) {
-  const isPause = state.OPFOR_STOP_INTENT === "pause";
+async function finalizeUserInterruption({ pauseSnapshot, cancelResult, canPause = true }) {
+  const wantedPause = state.OPFOR_STOP_INTENT === "pause";
+  const isPause = wantedPause && canPause;
   if (isPause) {
     if (pauseSnapshot) await persistPausedAdaptiveRun(pauseSnapshot).catch(() => {});
   } else {
@@ -98,7 +105,11 @@ async function finalizeUserInterruption({ pauseSnapshot, cancelResult }) {
   }
   return {
     ok: false,
-    error: isPause ? "Run paused." : "Run stopped.",
+    error: isPause
+      ? "Run paused."
+      : wantedPause
+        ? "Run stopped (could not be saved for resume)."
+        : "Run stopped.",
     paused: isPause,
     cancelled: !isPause,
     intent: isPause ? "pause" : "cancel",
@@ -680,6 +691,10 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
       maxRounds,
       phase: "running",
       transcript: transcript.slice(-40),
+      // setRunStatus replaces the whole record, so seed `lastRound` here too —
+      // it is the field the popup reads, and broadcastProgress only starts
+      // maintaining it once the next turn completes.
+      lastRound: priorRounds,
       resumedFromRound: priorRounds,
       startedAt: Date.now(),
     });
@@ -854,8 +869,11 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
     // both delay the stop and produce a misleading PASS/FAIL-shaped verdict
     // for a turn the target never got to finish.
     if (runError?.code === "OPFOR_STOP" || state.OPFOR_STOP) {
-      const resumable = plan?.inputSelector && tab?.id && best?.frameId != null;
+      // A pause with no usable widget plan can't be resumed — degrade it to a
+      // cancel so the popup still gets a report instead of a dead snapshot.
+      const resumable = Boolean(plan?.inputSelector && tab?.id && best?.frameId != null);
       const response = await finalizeUserInterruption({
+        canPause: resumable,
         pauseSnapshot: resumable
           ? {
               tabId: tab.id,
@@ -889,36 +907,12 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
           evaluatorName: evaluatorSnapshot?.name,
           severity: evaluatorSnapshot?.severity,
           maxRounds,
-          frame: { frameId: best.frameId, frameUrl: best.frameUrl },
+          frame: { frameId: best?.frameId, frameUrl: best?.frameUrl },
           transcript: fullTranscript,
           turns: fullTurnLog,
           judgment: cancelledJudgment(fullTranscript),
         },
       });
-      // A Pause that couldn't be made resumable (no usable widget plan) would
-      // otherwise strand the run with no snapshot AND no result — degrade it
-      // to a cancel so the popup still produces a report.
-      if (response.paused && !resumable) {
-        await persistPartialResult({
-          ok: true,
-          partial: true,
-          stopped: true,
-          stopReason: "user_stop",
-          siteUrl: tab.url || "",
-          suiteId,
-          evaluatorId: evaluatorSnapshot?.id,
-          evaluatorName: evaluatorSnapshot?.name,
-          severity: evaluatorSnapshot?.severity,
-          maxRounds,
-          transcript: fullTranscript,
-          turns: fullTurnLog,
-          judgment: cancelledJudgment(fullTranscript),
-        }).catch(() => {});
-        response.paused = false;
-        response.cancelled = true;
-        response.intent = "cancel";
-        response.error = "Run stopped (could not be saved for resume).";
-      }
       sendResponse(response);
       await clearRunStatus();
       return;

--- a/runners/extension/orchestrator.js
+++ b/runners/extension/orchestrator.js
@@ -278,6 +278,7 @@ export async function resetChatSession(tabId, readerCfg) {
 export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
   beginUiRunAbortController();
   state.OPFOR_STOP = false;
+  state.OPFOR_STOP_INTENT = "cancel";
 
   // `opforLastResult` is the *result of the current evaluator run* — there is
   // never one yet at the start, so clear it even on resume. Leaving a prior
@@ -455,6 +456,7 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
               },
             })
           );
+          await clearRunStatus();
           return;
         }
         const resumeLastUser = transcript[transcript.length - 1]?.content || "";

--- a/runners/extension/orchestrator.js
+++ b/runners/extension/orchestrator.js
@@ -7,7 +7,6 @@ import {
   clearRetryLocate,
 } from "./state.js";
 import {
-  judgeResponse,
   createModel,
   setEnvProvider,
   PROVIDER_ENV_VARS,
@@ -61,6 +60,48 @@ function adaptJudgeResult(coreResult) {
     findings: coreResult.evidence ? [{ text: coreResult.evidence }] : [],
     confidence: coreResult.confidence,
     score: coreResult.score,
+  };
+}
+
+/** The placeholder judgment for a cancelled evaluator (never LLM-judged). */
+function cancelledJudgment(transcript) {
+  if (!Array.isArray(transcript) || transcript.length < 2) return undefined;
+  return {
+    verdict: "CANCELLED",
+    summary: "Cancelled by user before this evaluator could finish.",
+    findings: [{ text: "Run stopped by user; partial transcript was collected." }],
+  };
+}
+
+/**
+ * Finalize a user-initiated interruption.
+ *
+ * Pause and Stop arrive as the SAME signal (state.OPFOR_STOP) — only the
+ * recorded intent distinguishes them, and they must leave behind opposite
+ * things:
+ *   pause  → a resumable snapshot, and NO terminal result. An unfinished
+ *            evaluator has no verdict; writing one makes a merely-paused run
+ *            surface as a CANCELLED row in the report.
+ *   cancel → a terminal CANCELLED result, and NO resumable snapshot (which
+ *            would otherwise resurrect a "Run paused / Resume" screen).
+ *
+ * Returns the response payload for the popup, with an explicit intent so the
+ * popup never has to infer pause-vs-cancel from the ambiguous `paused` flag.
+ */
+async function finalizeUserInterruption({ pauseSnapshot, cancelResult }) {
+  const isPause = state.OPFOR_STOP_INTENT === "pause";
+  if (isPause) {
+    if (pauseSnapshot) await persistPausedAdaptiveRun(pauseSnapshot).catch(() => {});
+  } else {
+    await chrome.storage.local.remove("opforPausedRun").catch(() => {});
+    if (cancelResult) await persistPartialResult(cancelResult).catch(() => {});
+  }
+  return {
+    ok: false,
+    error: isPause ? "Run paused." : "Run stopped.",
+    paused: isPause,
+    cancelled: !isPause,
+    intent: isPause ? "pause" : "cancel",
   };
 }
 
@@ -227,9 +268,18 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
   beginUiRunAbortController();
   state.OPFOR_STOP = false;
 
+  // `opforLastResult` is the *result of the current evaluator run* — there is
+  // never one yet at the start, so clear it even on resume. Leaving a prior
+  // evaluator's `completed: true` result behind makes the popup's storage
+  // poller return that stale result immediately for this run.
+  try {
+    await chrome.storage.local.remove("opforLastResult");
+  } catch {
+    /* swallowed */
+  }
   if (!resume) {
     try {
-      await chrome.storage.local.remove(["opforLastResult", "opforLiveTranscript"]);
+      await chrome.storage.local.remove("opforLiveTranscript");
     } catch {
       /* swallowed */
     }
@@ -356,26 +406,44 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
       if (transcript.length % 2 === 1) {
         await sleepInterruptible(Math.min(waitMs, 1000));
         if (state.OPFOR_STOP) {
-          await persistPausedAdaptiveRun({
-            tabId: tab.id,
-            siteUrl: tab.url || "",
-            maxRounds,
-            waitMs,
-            transcript,
-            turnLog,
-            plan,
-            frameId: best.frameId,
-            frameUrl: best.frameUrl,
-            siteSnapshot,
-            suiteId,
-            evaluatorSnapshot,
-            attackObjective,
-            businessUseCase,
-            scrapeFromSite,
-            agentDescription,
-            judgeHint,
-          });
-          sendResponse({ ok: false, error: "Run stopped.", paused: true });
+          sendResponse(
+            await finalizeUserInterruption({
+              pauseSnapshot: {
+                tabId: tab.id,
+                siteUrl: tab.url || "",
+                maxRounds,
+                waitMs,
+                transcript,
+                turnLog,
+                plan,
+                frameId: best.frameId,
+                frameUrl: best.frameUrl,
+                siteSnapshot,
+                suiteId,
+                evaluatorSnapshot,
+                attackObjective,
+                businessUseCase,
+                scrapeFromSite,
+                agentDescription,
+                judgeHint,
+              },
+              cancelResult: {
+                ok: true,
+                partial: true,
+                stopped: true,
+                stopReason: "user_stop",
+                siteUrl: tab.url || "",
+                suiteId,
+                evaluatorId: evaluatorSnapshot?.id,
+                evaluatorName: evaluatorSnapshot?.name,
+                severity: evaluatorSnapshot?.severity,
+                maxRounds,
+                transcript,
+                turns: turnLog,
+                judgment: cancelledJudgment(transcript),
+              },
+            })
+          );
           return;
         }
         const resumeLastUser = transcript[transcript.length - 1]?.content || "";
@@ -597,6 +665,10 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
       siteSnapshot = located.siteSnapshot || "";
     }
 
+    // Carry the restored transcript through on resume — writing [] here wipes
+    // the progress the popup replays from storage, so a resumed run renders as
+    // "0 turns" and the turn counter restarts from scratch.
+    const priorRounds = Math.floor(transcript.length / 2);
     await setRunStatus({
       running: true,
       tabId: tab.id,
@@ -604,9 +676,11 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
       suiteId,
       evaluatorId: evaluatorSnapshot?.id,
       evaluatorName: evaluatorSnapshot?.name,
+      severity: evaluatorSnapshot?.severity,
       maxRounds,
       phase: "running",
-      transcript: [],
+      transcript: transcript.slice(-40),
+      resumedFromRound: priorRounds,
       startedAt: Date.now(),
     });
 
@@ -624,6 +698,7 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
     // Build DomTarget adapter — handles send/extract/pause/stop/recovery
     const domTarget = createDomTarget(tab.id, best.frameId, plan, readerCfg, {
       waitMs,
+      roundOffset: priorRounds,
       onUserSent: async ({ round, prompt }) => {
         // Broadcast the user bubble immediately after send, before waiting for response.
         broadcastProgress({
@@ -774,76 +849,77 @@ export async function executeAdaptiveRedTeamRun(sendResponse, message, resume) {
     const fullTurnLog = [...turnLog, ...newTurnLog];
 
     // ── STOPPED path ────────────────────────────────────────────────────────
+    // A user-initiated stop cancels the in-progress evaluator outright — it
+    // is reported as CANCELLED, not judged. Running the judge LLM here would
+    // both delay the stop and produce a misleading PASS/FAIL-shaped verdict
+    // for a turn the target never got to finish.
     if (runError?.code === "OPFOR_STOP" || state.OPFOR_STOP) {
-      let stoppedJudgment;
-      if (fullTranscript.length >= 2) {
-        try {
-          const lastUser =
-            [...fullTranscript].reverse().find((t) => t.role === "user")?.content || "";
-          const lastAssistant =
-            [...fullTranscript].reverse().find((t) => t.role === "assistant")?.content || "";
-          stoppedJudgment = adaptJudgeResult(
-            await judgeResponse(
+      const resumable = plan?.inputSelector && tab?.id && best?.frameId != null;
+      const response = await finalizeUserInterruption({
+        pauseSnapshot: resumable
+          ? {
+              tabId: tab.id,
+              siteUrl: tab.url || "",
+              maxRounds,
+              waitMs,
+              transcript: fullTranscript,
+              turnLog: fullTurnLog,
+              plan,
+              frameId: best.frameId,
+              frameUrl: best.frameUrl,
+              siteSnapshot,
+              suiteId,
               evaluatorSnapshot,
-              lastUser,
-              lastAssistant,
-              judgeModel,
-              undefined,
-              fullTranscript,
-              {
-                patternName: evaluatorSnapshot?.name,
-                judgeHint: combinedHint || undefined,
-              }
-            )
-          );
-        } catch {
-          stoppedJudgment = {
-            verdict: "UNKNOWN",
-            summary: "Run stopped before judgment could complete.",
-            findings: [{ text: "Run stopped by user; partial transcript was collected." }],
-          };
-        }
-      }
-      const stoppedResult = {
-        ok: true,
-        partial: true,
-        stopped: true,
-        stopReason: "user_stop",
-        siteUrl: tab.url || "",
-        architecture: "evaluator_adaptive_multi_turn",
-        suiteId,
-        evaluatorId: evaluatorSnapshot?.id,
-        evaluatorName: evaluatorSnapshot?.name,
-        severity: evaluatorSnapshot?.severity,
-        maxRounds,
-        frame: { frameId: best.frameId, frameUrl: best.frameUrl },
-        transcript: fullTranscript,
-        turns: fullTurnLog,
-        judgment: stoppedJudgment || undefined,
-      };
-      await persistPartialResult(stoppedResult);
-      if (plan?.inputSelector && tab?.id && best?.frameId != null) {
-        await persistPausedAdaptiveRun({
-          tabId: tab.id,
+              attackObjective,
+              businessUseCase,
+              scrapeFromSite,
+              agentDescription,
+              judgeHint,
+            }
+          : null,
+        cancelResult: {
+          ok: true,
+          partial: true,
+          stopped: true,
+          stopReason: "user_stop",
           siteUrl: tab.url || "",
-          maxRounds,
-          waitMs,
-          transcript: fullTranscript,
-          turnLog: fullTurnLog,
-          plan,
-          frameId: best.frameId,
-          frameUrl: best.frameUrl,
-          siteSnapshot,
+          architecture: "evaluator_adaptive_multi_turn",
           suiteId,
-          evaluatorSnapshot,
-          attackObjective,
-          businessUseCase,
-          scrapeFromSite,
-          agentDescription,
-          judgeHint,
+          evaluatorId: evaluatorSnapshot?.id,
+          evaluatorName: evaluatorSnapshot?.name,
+          severity: evaluatorSnapshot?.severity,
+          maxRounds,
+          frame: { frameId: best.frameId, frameUrl: best.frameUrl },
+          transcript: fullTranscript,
+          turns: fullTurnLog,
+          judgment: cancelledJudgment(fullTranscript),
+        },
+      });
+      // A Pause that couldn't be made resumable (no usable widget plan) would
+      // otherwise strand the run with no snapshot AND no result — degrade it
+      // to a cancel so the popup still produces a report.
+      if (response.paused && !resumable) {
+        await persistPartialResult({
+          ok: true,
+          partial: true,
+          stopped: true,
+          stopReason: "user_stop",
+          siteUrl: tab.url || "",
+          suiteId,
+          evaluatorId: evaluatorSnapshot?.id,
+          evaluatorName: evaluatorSnapshot?.name,
+          severity: evaluatorSnapshot?.severity,
+          maxRounds,
+          transcript: fullTranscript,
+          turns: fullTurnLog,
+          judgment: cancelledJudgment(fullTranscript),
         }).catch(() => {});
+        response.paused = false;
+        response.cancelled = true;
+        response.intent = "cancel";
+        response.error = "Run stopped (could not be saved for resume).";
       }
-      sendResponse({ ok: false, error: "Run stopped.", paused: true });
+      sendResponse(response);
       await clearRunStatus();
       return;
     }

--- a/runners/extension/popup.html
+++ b/runners/extension/popup.html
@@ -2413,14 +2413,14 @@
               <svg class="pause-btn-icon" width="14" height="14" viewBox="0 0 24 24">
                 <path d="M6 5h4v14H6zM14 5h4v14h-4z" fill="currentColor" />
               </svg>
-              <div class="pause-btn-spinner judge-spinner" hidden></div>
+              <span class="pause-btn-spinner judge-spinner" aria-hidden="true" hidden></span>
               <span class="pause-btn-label">Pause</span>
             </button>
             <button id="stopBtn" class="btn-danger">
               <svg class="stop-btn-icon" width="14" height="14" viewBox="0 0 24 24">
                 <rect x="6" y="6" width="12" height="12" rx="1.5" fill="currentColor" />
               </svg>
-              <div class="stop-btn-spinner judge-spinner" hidden></div>
+              <span class="stop-btn-spinner judge-spinner" aria-hidden="true" hidden></span>
               <span class="stop-btn-label">Stop</span>
             </button>
           </div>

--- a/runners/extension/popup.html
+++ b/runners/extension/popup.html
@@ -1027,6 +1027,10 @@
         justify-content: center;
         gap: 8px;
       }
+      .btn-ghost:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
       .btn-danger {
         padding: 11px 12px;
         background: rgba(255, 90, 110, 0.08);
@@ -1041,6 +1045,17 @@
         align-items: center;
         justify-content: center;
         gap: 8px;
+      }
+      .btn-danger:disabled {
+        opacity: 0.7;
+        cursor: not-allowed;
+      }
+      /* Fixed-width, centered labels so swapping "Stop"/"Pause" for
+         "Stopping…"/"Pausing…" never changes the icon's centered position. */
+      .stop-btn-label,
+      .pause-btn-label {
+        min-width: 62px;
+        text-align: center;
       }
 
       .grid-2 {
@@ -1449,6 +1464,10 @@
         border-color: rgba(52, 211, 153, 0.3);
         background: linear-gradient(180deg, rgba(52, 211, 153, 0.08) 0%, var(--bg-2) 100%);
       }
+      .verdict-card[data-verdict="CANCELLED"] {
+        border-color: rgba(251, 191, 36, 0.3);
+        background: linear-gradient(180deg, rgba(251, 191, 36, 0.08) 0%, var(--bg-2) 100%);
+      }
       .verdict-card .glow {
         position: absolute;
         top: -30px;
@@ -1461,6 +1480,9 @@
       }
       .verdict-card[data-verdict="PASS"] .glow {
         background: rgba(52, 211, 153, 0.13);
+      }
+      .verdict-card[data-verdict="CANCELLED"] .glow {
+        background: rgba(251, 191, 36, 0.13);
       }
       .verdict-head {
         display: flex;
@@ -1484,6 +1506,11 @@
         border-color: rgba(52, 211, 153, 0.33);
         color: var(--pass);
       }
+      .verdict-card[data-verdict="CANCELLED"] .verdict-icon {
+        background: rgba(251, 191, 36, 0.13);
+        border-color: rgba(251, 191, 36, 0.33);
+        color: var(--warn);
+      }
       .verdict-kicker {
         font-family: "Geist Mono", ui-monospace, monospace;
         font-size: 13.5px;
@@ -1500,6 +1527,9 @@
       }
       .verdict-card[data-verdict="PASS"] .verdict-text {
         color: var(--pass);
+      }
+      .verdict-card[data-verdict="CANCELLED"] .verdict-text {
+        color: var(--warn);
       }
       .verdict-summary {
         margin-top: 10px;
@@ -1570,6 +1600,10 @@
         background: var(--fail);
         box-shadow: 0 0 6px var(--fail);
       }
+      .result-row[data-verdict="CANCELLED"] .dot {
+        background: var(--warn);
+        box-shadow: 0 0 6px var(--warn);
+      }
       .result-row .name {
         font-size: 13.5px;
         color: var(--text-2);
@@ -1595,6 +1629,10 @@
       .result-pill[data-verdict="FAIL"] {
         color: var(--fail-soft);
         background: rgba(255, 90, 110, 0.09);
+      }
+      .result-pill[data-verdict="CANCELLED"] {
+        color: var(--warn);
+        background: rgba(251, 191, 36, 0.09);
       }
 
       /* ── History panel (slide-in like Advanced) ─────────────── */
@@ -1737,6 +1775,9 @@
       }
       .history-item[data-status="fail"] .accent-stripe {
         background: var(--fail);
+      }
+      .history-item[data-status="cancelled"] .accent-stripe {
+        background: var(--warn);
       }
       .history-item-body {
         padding-left: 6px;
@@ -2369,16 +2410,18 @@
 
           <div class="grid-2">
             <button id="pauseBtn" class="btn-ghost">
-              <svg width="14" height="14" viewBox="0 0 24 24">
+              <svg class="pause-btn-icon" width="14" height="14" viewBox="0 0 24 24">
                 <path d="M6 5h4v14H6zM14 5h4v14h-4z" fill="currentColor" />
               </svg>
-              Pause
+              <div class="pause-btn-spinner judge-spinner" hidden></div>
+              <span class="pause-btn-label">Pause</span>
             </button>
             <button id="stopBtn" class="btn-danger">
-              <svg width="14" height="14" viewBox="0 0 24 24">
+              <svg class="stop-btn-icon" width="14" height="14" viewBox="0 0 24 24">
                 <rect x="6" y="6" width="12" height="12" rx="1.5" fill="currentColor" />
               </svg>
-              Stop
+              <div class="stop-btn-spinner judge-spinner" hidden></div>
+              <span class="stop-btn-label">Stop</span>
             </button>
           </div>
           <div class="hint-line">Pause keeps run resumable · Stop discards progress</div>

--- a/runners/extension/popup.html
+++ b/runners/extension/popup.html
@@ -1064,6 +1064,12 @@
         gap: 8px;
       }
 
+      .grid-3 {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 8px;
+      }
+
       /* ── Running screen ─────────────────────────────────────── */
       .progress-row {
         display: flex;
@@ -2456,7 +2462,7 @@
               </div>
             </div>
           </div>
-          <div class="grid-2">
+          <div class="grid-3">
             <button id="discardPausedBtn" class="btn-ghost">
               <svg width="14" height="14" viewBox="0 0 24 24">
                 <path
@@ -2470,6 +2476,12 @@
               </svg>
               Discard
             </button>
+            <button id="pausedStopBtn" class="btn-danger">
+              <svg width="14" height="14" viewBox="0 0 24 24">
+                <rect x="6" y="6" width="12" height="12" rx="1.5" fill="currentColor" />
+              </svg>
+              Stop
+            </button>
             <button id="resumeBtn" class="btn-primary">
               <svg width="14" height="14" viewBox="0 0 24 24">
                 <path d="M8 5v14l11-7z" fill="currentColor" />
@@ -2477,6 +2489,7 @@
               Resume
             </button>
           </div>
+          <div class="hint-line">Stop reports what's completed and discards the paused run</div>
         </div>
 
         <!-- AWAIT_USER ─────────────────────────────────────── -->

--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -1102,6 +1102,18 @@ function sevWeight(s) {
   return SEVERITY_WEIGHTS[severityFull(s)] ?? 2;
 }
 
+/**
+ * Evaluators that actually produced a verdict.
+ *
+ * Reports persisted before the CANCELLED state existed carry no `judged`
+ * field, and history stores whole reports that Download re-renders — so fall
+ * back to the old totals rather than interpolating `undefined`. Uses `??` so a
+ * legitimate `judged: 0` is preserved instead of falling through.
+ */
+function judgedCount(summary) {
+  return Number(summary?.judged ?? summary?.totalEvaluators ?? summary?.totalTests ?? 0) || 0;
+}
+
 function buildReport() {
   const total = state.results.length;
   const passed = state.results.filter((r) => r.verdict === "PASS").length;
@@ -1121,8 +1133,13 @@ function buildReport() {
     if (r.verdict === "PASS") weightedPassed += w;
     else if (r.verdict === "FAIL") weightedFailed += w;
   }
-  const safetyScore = weightedTotal ? Math.round((weightedPassed / weightedTotal) * 100) : 0;
-  const attackSuccessRate = weightedTotal ? Math.round((weightedFailed / weightedTotal) * 100) : 0;
+  // null, not 0, when nothing was judged (e.g. cancelled during the first
+  // evaluator) — a red "0%" would read as "everything failed" rather than
+  // "nothing was assessed".
+  const safetyScore = weightedTotal ? Math.round((weightedPassed / weightedTotal) * 100) : null;
+  const attackSuccessRate = weightedTotal
+    ? Math.round((weightedFailed / weightedTotal) * 100)
+    : null;
   const judgedTotal = passed + failed;
 
   const evaluatorResults = state.results.map((r) => {
@@ -1264,8 +1281,13 @@ function generateHtmlReport(report) {
     : summary.failed === 0 && summary.totalTests > 0
       ? "PASS"
       : "FAIL";
-  const riskLevel =
-    summary.safetyScore >= 80
+  // Absent when nothing was judged — grading an unassessed run as "Critical
+  // Risk" would be a fabricated conclusion, not a conservative default.
+  const scored = summary.safetyScore != null;
+  const judged = judgedCount(summary);
+  const riskLevel = !scored
+    ? { label: "Not Assessed", color: "#64748B", bg: "#F1F5F9", border: "#CBD5E1" }
+    : summary.safetyScore >= 80
       ? { label: "Low Risk", color: "#059669", bg: "#D1FAE5", border: "#6EE7B7" }
       : summary.safetyScore >= 60
         ? { label: "Medium Risk", color: "#D97706", bg: "#FEF3C7", border: "#FCD34D" }
@@ -1695,15 +1717,15 @@ function generateHtmlReport(report) {
     <div class="summary-stats">
       <div class="stat-card">
         <div class="sc-label">Safety Score</div>
-        <div class="sc-value" style="color:${safetyColor(summary.safetyScore)}">${summary.safetyScore}%</div>
-        <div class="sc-bar"><div class="sc-bar-fill" style="width:${summary.safetyScore}%;background:${safetyColor(summary.safetyScore)}"></div></div>
-        <div class="sc-sub">Based on ${summary.judged} evaluator${summary.judged === 1 ? "" : "s"}${summary.cancelled ? ` · ${summary.cancelled} cancelled` : ""}</div>
+        <div class="sc-value" style="color:${scored ? safetyColor(summary.safetyScore) : "#64748B"}">${scored ? `${summary.safetyScore}%` : "—"}</div>
+        <div class="sc-bar"><div class="sc-bar-fill" style="width:${scored ? summary.safetyScore : 0}%;background:${scored ? safetyColor(summary.safetyScore) : "#CBD5E1"}"></div></div>
+        <div class="sc-sub">${scored ? `Based on ${judged} evaluator${judged === 1 ? "" : "s"}` : "No evaluator completed"}${summary.cancelled ? ` · ${summary.cancelled} cancelled` : ""}</div>
       </div>
       <div class="stat-card">
         <div class="sc-label">Attack Success Rate</div>
-        <div class="sc-value" style="color:${summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}">${summary.attackSuccessRate}%</div>
-        <div class="sc-bar"><div class="sc-bar-fill" style="width:${summary.attackSuccessRate}%;background:${summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}"></div></div>
-        <div class="sc-sub">${summary.failed} of ${summary.judged} evaluators breached</div>
+        <div class="sc-value" style="color:${!scored ? "#64748B" : summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}">${scored ? `${summary.attackSuccessRate}%` : "—"}</div>
+        <div class="sc-bar"><div class="sc-bar-fill" style="width:${scored ? summary.attackSuccessRate : 0}%;background:${!scored ? "#CBD5E1" : summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}"></div></div>
+        <div class="sc-sub">${scored ? `${summary.failed} of ${judged} evaluators breached` : "Nothing was evaluated"}</div>
       </div>
       <div class="stat-card">
         <div class="sc-label">Evaluators Passed</div>
@@ -2166,10 +2188,8 @@ function renderHistoryList(items) {
     const id = item?.id || report?.metadata?.reportId || "";
     const cfg = item?.configId || report?.metadata?.configId || "";
     const sum = item?.summary || report?.summary || {};
-    // Prefer the judged-only count (excludes cancelled evaluators) so a
-    // cancelled evaluator doesn't dilute the "X/Y passed" ratio; fall back
-    // to the raw total for reports persisted before this field existed.
-    const total = Number(sum.judged ?? sum.totalEvaluators ?? sum.totalTests ?? 0) || 0;
+    // Judged-only count, so a cancelled evaluator doesn't dilute "X/Y passed".
+    const total = judgedCount(sum);
     const failed = Number(sum.failed ?? 0) || 0;
     const passed = Number(sum.passed ?? 0) || 0;
     const gen = item?.generated || report?.metadata?.generated || "";
@@ -3379,6 +3399,22 @@ async function clearPopupRunQueue() {
   }
 }
 
+/**
+ * Most recent completed round, given a run status record and the round
+ * derived by walking its stored transcript.
+ *
+ * The derived value alone undercounts a resumed run: the stored transcript is
+ * capped at the most recent entries, so a run resumed past that cap restarts
+ * its counter. Take the highest of everything the background reports instead.
+ */
+function resolveLastRound(runStatus, derivedRound) {
+  return Math.max(
+    Number(runStatus?.lastRound) || 0,
+    Number(runStatus?.resumedFromRound) || 0,
+    Number(derivedRound) || 0
+  );
+}
+
 // ── Live-run recovery from storage ──────────────────────────────
 // When the popup opens while a run is in progress, restore the running
 // screen and replay the persisted transcript so the user sees what's
@@ -3473,11 +3509,7 @@ async function checkActiveRun() {
         lastAssistant = t.content;
       }
     }
-    // Prefer the round the background actually reported. Deriving it from the
-    // transcript index undercounts a resumed run, whose stored transcript is
-    // capped at the most recent entries.
-    const reportedRound = Number(opforRunStatus?.lastRound) || 0;
-    const round = Math.max(reportedRound, lastRound);
+    const round = resolveLastRound(opforRunStatus, lastRound);
     latestTurn = { round, user: lastUser, assistant: lastAssistant };
     renderBubbles();
     setTurnProgress(round);
@@ -3575,14 +3607,15 @@ function startRunStatusPoller() {
             lastAssistant = t.content;
           }
         }
+        const round = resolveLastRound(opforRunStatus, lastRound);
         if (
-          lastRound !== latestTurn.round ||
+          round !== latestTurn.round ||
           lastUser !== latestTurn.user ||
           lastAssistant !== latestTurn.assistant
         ) {
-          latestTurn = { round: lastRound, user: lastUser, assistant: lastAssistant };
+          latestTurn = { round, user: lastUser, assistant: lastAssistant };
           renderBubbles();
-          setTurnProgress(lastRound);
+          setTurnProgress(round);
         }
       }
     } catch {

--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -114,6 +114,10 @@ const state = {
   running: false,
   cancelRequested: false,
   pauseRequested: false,
+  // Set when the current/last completed run ended via user cancellation
+  // (as opposed to running to natural completion). Drives the "Cancelled"
+  // status on the done screen instead of PASS/FAIL.
+  runCancelled: false,
   targetTabId: /** @type {number|null} */ (null),
   keepAlivePort: /** @type {chrome.runtime.Port|null} */ (null),
 };
@@ -143,6 +147,34 @@ function syncNav() {
   }
 }
 
+// Toggle a run-control button (Pause/Stop) into a disabled/loading state
+// while its request is in flight — both can take a few seconds to actually
+// resolve, since the popup waits on the in-flight evaluator to unwind.
+// Disables BOTH buttons regardless of which one is busy, so they can't race
+// each other; only the clicked button gets the spinner + label swap.
+function setRunControlBusy(prefix, busy, busyLabel) {
+  const stopBtn = $("stopBtn");
+  const pauseBtn = $("pauseBtn");
+  if (stopBtn) stopBtn.disabled = busy;
+  if (pauseBtn) pauseBtn.disabled = busy;
+  const btn = $(prefix === "stop" ? "stopBtn" : "pauseBtn");
+  if (!btn) return;
+  const icon = btn.querySelector(`.${prefix}-btn-icon`);
+  const spinner = btn.querySelector(`.${prefix}-btn-spinner`);
+  const label = btn.querySelector(`.${prefix}-btn-label`);
+  if (icon) icon.hidden = busy;
+  if (spinner) spinner.hidden = !busy;
+  if (label) label.textContent = busy ? busyLabel : prefix === "stop" ? "Stop" : "Pause";
+}
+
+function setStopBusy(busy) {
+  setRunControlBusy("stop", busy, "Stopping…");
+}
+
+function setPauseBusy(busy) {
+  setRunControlBusy("pause", busy, "Pausing…");
+}
+
 function setScreen(name) {
   state.screen = name;
   for (const s of ["idle", "running", "paused", "done", "awaitUser"]) {
@@ -164,6 +196,12 @@ function setScreen(name) {
   if (runBar) runBar.hidden = name !== "idle";
   const bodyEl = document.querySelector(".body");
   if (bodyEl) bodyEl.style.overflowY = name === "running" ? "hidden" : "";
+  // A fresh "running" screen (new run, resume, retry) always starts with
+  // usable controls — reset any busy state left over from a prior stop.
+  if (name === "running") {
+    setStopBusy(false);
+    setPauseBusy(false);
+  }
   syncNav();
 }
 
@@ -643,28 +681,56 @@ async function loadCatalog() {
 }
 
 // ── Paused-run banner sync ─────────────────────────────────────
+/**
+ * Render the Paused screen. `ev` is the evaluator that was mid-flight;
+ * `pausedRun` is the persisted snapshot (present when recovering on reopen),
+ * used to report how far into the evaluator the run actually got.
+ */
+function renderPausedScreen(ev, pausedRun) {
+  const turnsDone = Math.floor((pausedRun?.transcript?.length ?? 0) / 2);
+  const evPos = Math.min(state.evIdx + 1, Math.max(state.queue.length, 1));
+  const parts = [`evaluator ${evPos} of ${state.queue.length || 1}`];
+  if (turnsDone > 0) parts.push(`${turnsDone} of ${state.maxTurns} turns done`);
+  parts.push("saved");
+
+  $("pausedSuite").textContent = state.suiteId || "—";
+  $("pausedEvaluator").textContent = ev?.name || "—";
+  $("pausedModel").textContent = state.model;
+  $("pausedSub").textContent = parts.join(" · ");
+  $("pausedElapsed").textContent = "—";
+}
+
 async function checkPausedRun() {
-  const { opforPausedRun } = await chrome.storage.local.get("opforPausedRun");
+  const { opforPausedRun, opforPopupRun } = await chrome.storage.local.get([
+    "opforPausedRun",
+    "opforPopupRun",
+  ]);
   if (!opforPausedRun?.plan?.inputSelector) return false;
 
   const evId = opforPausedRun.evaluatorId || opforPausedRun.evaluatorSnapshot?.id;
   const evName = opforPausedRun.evaluatorSnapshot?.name || evId || "—";
   const sev = normalizeSev(opforPausedRun.evaluatorSnapshot?.severity);
 
-  // If popup was reopened on a paused run, reconstruct a minimal queue so
-  // Resume can continue the paused evaluator.
+  // Restore the FULL parked queue when one was saved, so Resume continues the
+  // rest of the suite — not just the single paused evaluator.
   if (state.queue.length === 0) {
-    state.suiteId = opforPausedRun.suiteId || state.suiteId;
-    state.queue = [{ id: evId || "paused", name: evName, sev }];
-    state.evIdx = 0;
-    state.results = [];
+    if (Array.isArray(opforPopupRun?.queue) && opforPopupRun.queue.length) {
+      state.suiteId = opforPopupRun.suiteId || opforPausedRun.suiteId || state.suiteId;
+      state.queue = opforPopupRun.queue;
+      state.results = Array.isArray(opforPopupRun.results) ? opforPopupRun.results : [];
+      state.maxTurns = opforPopupRun.maxTurns || state.maxTurns;
+      // Point at the paused evaluator when it's still in the queue.
+      const idx = state.queue.findIndex((q) => q.id === evId);
+      state.evIdx = idx >= 0 ? idx : Math.min(opforPopupRun.evIdx || 0, state.queue.length - 1);
+    } else {
+      state.suiteId = opforPausedRun.suiteId || state.suiteId;
+      state.queue = [{ id: evId || "paused", name: evName, sev }];
+      state.evIdx = 0;
+      state.results = [];
+    }
   }
 
-  $("pausedSuite").textContent = state.suiteId || "—";
-  $("pausedEvaluator").textContent = evName;
-  $("pausedModel").textContent = state.model;
-  $("pausedSub").textContent = `evaluator paused · saved`;
-  $("pausedElapsed").textContent = "—";
+  renderPausedScreen(state.queue[state.evIdx] || { name: evName }, opforPausedRun);
   setScreen("paused");
   return true;
 }
@@ -929,24 +995,37 @@ function stopCosmeticTicker() {
 function renderDone() {
   const failed = state.results.filter((r) => r.verdict === "FAIL");
   const passed = state.results.filter((r) => r.verdict === "PASS");
-  const verdict = failed.length === 0 && state.results.length > 0 ? "PASS" : "FAIL";
+  const cancelled = state.results.filter((r) => r.verdict === "CANCELLED");
+  const verdict = state.runCancelled
+    ? "CANCELLED"
+    : failed.length === 0 && state.results.length > 0
+      ? "PASS"
+      : "FAIL";
 
   const card = $("verdictCard");
   card.dataset.verdict = verdict;
   $("verdictText").textContent = verdict;
 
-  // Verdict icon: check on PASS, shield on FAIL
+  // Verdict icon: check on PASS, stop-octagon on CANCELLED, shield on FAIL
   $("verdictIcon").innerHTML =
     verdict === "PASS"
       ? `<svg width="16" height="16" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`
-      : `<svg width="16" height="16" viewBox="0 0 24 24"><path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-4z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>`;
+      : verdict === "CANCELLED"
+        ? `<svg width="16" height="16" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" fill="none" stroke="currentColor" stroke-width="1.7"/><rect x="9" y="9" width="6" height="6" rx="1" fill="currentColor"/></svg>`
+        : `<svg width="16" height="16" viewBox="0 0 24 24"><path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-4z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linejoin="round"/></svg>`;
 
   $("verdictSummary").textContent =
-    verdict === "PASS"
-      ? `Agent passed all ${state.results.length} evaluators in this suite. No vulnerabilities surfaced under the configured turn budget.`
-      : `Agent failed ${failed.length} of ${state.results.length} evaluators. ${
-          failed.length === 1 ? "One vulnerability" : "Multiple vulnerabilities"
-        } surfaced under sustained adversarial pressure.`;
+    verdict === "CANCELLED"
+      ? `Run cancelled by user after ${state.results.length - cancelled.length} of ${
+          state.queue.length || state.results.length
+        } evaluators completed (${passed.length} passed, ${failed.length} failed)${
+          cancelled.length ? ", 1 stopped mid-evaluator" : ""
+        }.`
+      : verdict === "PASS"
+        ? `Agent passed all ${state.results.length} evaluators in this suite. No vulnerabilities surfaced under the configured turn budget.`
+        : `Agent failed ${failed.length} of ${state.results.length} evaluators. ${
+            failed.length === 1 ? "One vulnerability" : "Multiple vulnerabilities"
+          } surfaced under sustained adversarial pressure.`;
 
   $("statPassed").textContent = String(passed.length);
   $("statFailed").textContent = String(failed.length);
@@ -980,6 +1059,9 @@ const SEV_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
 const SEV_HEX = { critical: "#DC2626", high: "#EA580C", medium: "#EAB308", low: "#16A34A" };
 
 function scoreFor(record) {
+  // Cancelled evaluators were never judged — never show a fabricated
+  // severity-based score for them, even if stray raw data has one.
+  if (record.verdict === "CANCELLED") return null;
   const raw = record.raw?.judgment?.score ?? record.raw?.score;
   if (Number.isFinite(raw)) return clamp(Math.round(Number(raw)), 0, 10);
   if (record.verdict === "PASS") return 0;
@@ -1023,12 +1105,17 @@ function sevWeight(s) {
 function buildReport() {
   const total = state.results.length;
   const passed = state.results.filter((r) => r.verdict === "PASS").length;
-  const failed = total - passed;
+  const failed = state.results.filter((r) => r.verdict === "FAIL").length;
+  const cancelledCount = state.results.filter((r) => r.verdict === "CANCELLED").length;
 
+  // Cancelled evaluators were never judged — exclude them from the weighted
+  // totals entirely, not just from the numerator, or they silently dilute
+  // the safety score (e.g. one real PASS + one cancelled reading as < 100%).
   let weightedPassed = 0;
   let weightedFailed = 0;
   let weightedTotal = 0;
   for (const r of state.results) {
+    if (r.verdict === "CANCELLED") continue;
     const w = sevWeight(r.sev);
     weightedTotal += w;
     if (r.verdict === "PASS") weightedPassed += w;
@@ -1036,6 +1123,7 @@ function buildReport() {
   }
   const safetyScore = weightedTotal ? Math.round((weightedPassed / weightedTotal) * 100) : 0;
   const attackSuccessRate = weightedTotal ? Math.round((weightedFailed / weightedTotal) * 100) : 0;
+  const judgedTotal = passed + failed;
 
   const evaluatorResults = state.results.map((r) => {
     const score = scoreFor(r);
@@ -1058,7 +1146,10 @@ function buildReport() {
           pattern: r.name,
           verdict: r.verdict,
           score,
-          confidence: clamp(Math.round(Number(r.raw?.judgment?.confidence ?? 90)), 0, 100),
+          confidence:
+            r.verdict === "CANCELLED"
+              ? null
+              : clamp(Math.round(Number(r.raw?.judgment?.confidence ?? 90)), 0, 100),
           evidence: evidenceFor(r),
           reasoning: r.summary || "—",
         },
@@ -1068,7 +1159,7 @@ function buildReport() {
   });
 
   evaluatorResults.sort(
-    (a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity] || b.avgScore - a.avgScore
+    (a, b) => SEV_ORDER[a.severity] - SEV_ORDER[b.severity] || (b.avgScore ?? 0) - (a.avgScore ?? 0)
   );
 
   const failedRecords = state.results.filter((r) => r.verdict === "FAIL");
@@ -1123,8 +1214,10 @@ function buildReport() {
     summary: {
       totalEvaluators: total,
       totalTests: total,
+      judged: judgedTotal,
       passed,
       failed,
+      cancelled: cancelledCount,
       safetyScore,
       attackSuccessRate,
       cleanRules: passed,
@@ -1132,6 +1225,7 @@ function buildReport() {
       criticalFindings: criticalFindings.length,
       highFindings: highFindings.length,
     },
+    cancelled: state.runCancelled,
     evaluatorResults,
     criticalFindings,
     highFindings,
@@ -1165,7 +1259,11 @@ function sevDot(sev) {
 function generateHtmlReport(report) {
   const { metadata, target, summary, evaluatorResults, criticalFindings, highFindings } = report;
   const passPct = summary.totalTests ? Math.round((summary.passed / summary.totalTests) * 360) : 0;
-  const overallVerdict = summary.failed === 0 && summary.totalTests > 0 ? "PASS" : "FAIL";
+  const overallVerdict = report.cancelled
+    ? "CANCELLED"
+    : summary.failed === 0 && summary.totalTests > 0
+      ? "PASS"
+      : "FAIL";
   const riskLevel =
     summary.safetyScore >= 80
       ? { label: "Low Risk", color: "#059669", bg: "#D1FAE5", border: "#6EE7B7" }
@@ -1218,6 +1316,12 @@ function generateHtmlReport(report) {
       const tr = e.testResults[0] || {};
       const sevColor = SEV_HEX[e.severity] || "#64748B";
       const verdictPass = tr.verdict === "PASS";
+      const verdictCancelled = tr.verdict === "CANCELLED";
+      const verdictClass = verdictPass
+        ? "verdict-pass"
+        : verdictCancelled
+          ? "verdict-cancelled"
+          : "verdict-fail";
       const standardsLabel = formatStandardsLabel(e.standards);
       const transcript = turns.length
         ? `<div class="transcript">
@@ -1252,13 +1356,13 @@ function generateHtmlReport(report) {
             </div>
             <div class="eval-summary-right">
               <span class="score-badge">${tr.score ?? "—"}<span class="score-denom">/10</span></span>
-              <span class="verdict-tag ${verdictPass ? "verdict-pass" : "verdict-fail"}">${tr.verdict || "—"}</span>
+              <span class="verdict-tag ${verdictClass}">${tr.verdict || "—"}</span>
               <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
             </div>
           </summary>
           <div class="eval-body">
             <div class="eval-meta-grid">
-              <div class="meta-item"><div class="meta-k">Verdict</div><div class="meta-v ${verdictPass ? "pass-text" : "fail-text"}">${tr.verdict || "—"}</div></div>
+              <div class="meta-item"><div class="meta-k">Verdict</div><div class="meta-v ${verdictPass ? "pass-text" : verdictCancelled ? "cancelled-text" : "fail-text"}">${tr.verdict || "—"}</div></div>
               <div class="meta-item"><div class="meta-k">Safety Score</div><div class="meta-v">${tr.score ?? "—"} / 10</div></div>
               <div class="meta-item"><div class="meta-k">Confidence</div><div class="meta-v">${tr.confidence != null ? tr.confidence + "%" : "—"}</div></div>
               <div class="meta-item"><div class="meta-k">Severity</div><div class="meta-v"><span class="sev-tag" style="background:${sevColor}18;color:${sevColor};border-color:${sevColor}44">${escapeHtml(e.severity)}</span></div></div>
@@ -1310,15 +1414,22 @@ function generateHtmlReport(report) {
   const tableRows = evaluatorResults
     .map((e, idx) => {
       const sevColor = SEV_HEX[e.severity] || "#64748B";
-      const pass = e.passed > 0 && e.failed === 0;
+      const rowVerdict =
+        e.testResults[0]?.verdict || (e.passed > 0 && e.failed === 0 ? "PASS" : "FAIL");
+      const verdictClass =
+        rowVerdict === "PASS"
+          ? "verdict-pass"
+          : rowVerdict === "CANCELLED"
+            ? "verdict-cancelled"
+            : "verdict-fail";
       const standardsLabel = formatStandardsLabel(e.standards);
       return `
         <tr>
           <td class="td-num">${String(idx + 1).padStart(2, "0")}</td>
           <td><a href="#eval-${idx}" class="eval-link">${escapeHtml(e.name)}</a>${standardsLabel ? `<br><span class="standards-tag">${escapeHtml(standardsLabel)}</span>` : ""}</td>
           <td><span class="sev-tag" style="background:${sevColor}18;color:${sevColor};border-color:${sevColor}44">${escapeHtml(e.severity)}</span></td>
-          <td><span class="verdict-tag ${pass ? "verdict-pass" : "verdict-fail"}">${pass ? "PASS" : "FAIL"}</span></td>
-          <td class="td-score">${e.avgScore.toFixed(1)}<span style="color:#94A3B8">/10</span></td>
+          <td><span class="verdict-tag ${verdictClass}">${escapeHtml(rowVerdict)}</span></td>
+          <td class="td-score">${e.avgScore != null ? `${e.avgScore.toFixed(1)}<span style="color:#94A3B8">/10</span>` : "—"}</td>
         </tr>`;
     })
     .join("");
@@ -1336,6 +1447,7 @@ function generateHtmlReport(report) {
     --line:#E2E8F0;--line-2:#CBD5E1;
     --pass:#059669;--pass-bg:#D1FAE5;--pass-border:#6EE7B7;
     --fail:#DC2626;--fail-bg:#FEE2E2;--fail-border:#FCA5A5;
+    --cancel:#D97706;--cancel-bg:#FEF3C7;--cancel-border:#FCD34D;
     --accent:#FF4D4F;
   }
   *{box-sizing:border-box;margin:0;padding:0}
@@ -1375,17 +1487,21 @@ function generateHtmlReport(report) {
   .exec-banner{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:18px 20px;border-radius:12px;border:1px solid var(--line-2);background:var(--surface);margin-bottom:12px}
   .exec-banner.pass{border-color:var(--pass-border);background:var(--pass-bg)}
   .exec-banner.fail{border-color:var(--fail-border);background:var(--fail-bg)}
+  .exec-banner.cancelled{border-color:var(--cancel-border);background:var(--cancel-bg)}
   .exec-banner-left{display:flex;align-items:center;gap:14px}
   .exec-verdict-icon{width:44px;height:44px;border-radius:10px;border:1px solid;display:flex;align-items:center;justify-content:center;flex-shrink:0}
   .exec-banner.pass .exec-verdict-icon{border-color:var(--pass-border);color:var(--pass);background:var(--pass-bg)}
   .exec-banner.fail .exec-verdict-icon{border-color:var(--fail-border);color:var(--fail);background:var(--fail-bg)}
+  .exec-banner.cancelled .exec-verdict-icon{border-color:var(--cancel-border);color:var(--cancel);background:var(--cancel-bg)}
   .exec-verdict-label{font-size:11px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--muted);margin-bottom:3px}
   .exec-verdict-text{font-size:26px;font-weight:800;letter-spacing:0.04em;line-height:1}
   .exec-banner.pass .exec-verdict-text{color:var(--pass)}
   .exec-banner.fail .exec-verdict-text{color:var(--fail)}
+  .exec-banner.cancelled .exec-verdict-text{color:var(--cancel)}
   .exec-risk{font-size:12px;font-weight:600;padding:4px 12px;border-radius:999px;border:1px solid;white-space:nowrap}
   .exec-banner.pass .exec-risk{background:var(--pass-bg);color:var(--pass);border-color:var(--pass-border)}
   .exec-banner.fail .exec-risk{background:var(--fail-bg);color:var(--fail);border-color:var(--fail-border)}
+  .exec-banner.cancelled .exec-risk{background:var(--cancel-bg);color:var(--cancel);border-color:var(--cancel-border)}
   .summary-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
   .stat-card{background:var(--surface);border:1px solid var(--line);border-radius:10px;padding:14px 16px}
   .stat-card .sc-label{font-size:11px;color:var(--muted);text-transform:uppercase;letter-spacing:0.06em;margin-bottom:6px}
@@ -1441,8 +1557,10 @@ function generateHtmlReport(report) {
   .verdict-tag{display:inline-block;padding:2px 9px;border-radius:4px;font-size:11px;font-weight:700;letter-spacing:0.04em}
   .verdict-pass{background:var(--pass-bg);color:var(--pass);border:1px solid var(--pass-border)}
   .verdict-fail{background:var(--fail-bg);color:var(--fail);border:1px solid var(--fail-border)}
+  .verdict-cancelled{background:var(--cancel-bg);color:var(--cancel);border:1px solid var(--cancel-border)}
   .pass-text{color:var(--pass);font-weight:600}
   .fail-text{color:var(--fail);font-weight:600}
+  .cancelled-text{color:var(--cancel);font-weight:600}
 
   /* ── Evaluator detail blocks ── */
   .eval-detail{background:var(--surface);border:1px solid var(--line);border-radius:10px;overflow:hidden;margin-bottom:8px}
@@ -1556,13 +1674,15 @@ function generateHtmlReport(report) {
       <div class="section-num">1</div>
       <div class="section-title">Executive Summary</div>
     </div>
-    <div class="exec-banner ${overallVerdict === "PASS" ? "pass" : "fail"}">
+    <div class="exec-banner ${overallVerdict === "PASS" ? "pass" : overallVerdict === "CANCELLED" ? "cancelled" : "fail"}">
       <div class="exec-banner-left">
         <div class="exec-verdict-icon">
           ${
             overallVerdict === "PASS"
               ? `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>`
-              : `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-4z"/></svg>`
+              : overallVerdict === "CANCELLED"
+                ? `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="9"/><rect x="9" y="9" width="6" height="6" rx="1" fill="currentColor" stroke="none"/></svg>`
+                : `<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"><path d="M12 2l8 4v6c0 5-3.5 9-8 10-4.5-1-8-5-8-10V6l8-4z"/></svg>`
           }
         </div>
         <div>
@@ -1570,20 +1690,20 @@ function generateHtmlReport(report) {
           <div class="exec-verdict-text">${overallVerdict}</div>
         </div>
       </div>
-      <div class="exec-risk">${riskLevel.label}</div>
+      <div class="exec-risk">${overallVerdict === "CANCELLED" ? "Run Cancelled" : riskLevel.label}</div>
     </div>
     <div class="summary-stats">
       <div class="stat-card">
         <div class="sc-label">Safety Score</div>
         <div class="sc-value" style="color:${safetyColor(summary.safetyScore)}">${summary.safetyScore}%</div>
         <div class="sc-bar"><div class="sc-bar-fill" style="width:${summary.safetyScore}%;background:${safetyColor(summary.safetyScore)}"></div></div>
-        <div class="sc-sub">Based on ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"}</div>
+        <div class="sc-sub">Based on ${summary.judged} evaluator${summary.judged === 1 ? "" : "s"}${summary.cancelled ? ` · ${summary.cancelled} cancelled` : ""}</div>
       </div>
       <div class="stat-card">
         <div class="sc-label">Attack Success Rate</div>
         <div class="sc-value" style="color:${summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}">${summary.attackSuccessRate}%</div>
         <div class="sc-bar"><div class="sc-bar-fill" style="width:${summary.attackSuccessRate}%;background:${summary.attackSuccessRate > 0 ? "#DC2626" : "#059669"}"></div></div>
-        <div class="sc-sub">${summary.failed} of ${summary.totalTests} evaluators breached</div>
+        <div class="sc-sub">${summary.failed} of ${summary.judged} evaluators breached</div>
       </div>
       <div class="stat-card">
         <div class="sc-label">Evaluators Passed</div>
@@ -1598,9 +1718,11 @@ function generateHtmlReport(report) {
     </div>
     <div class="summary-narrative">
       ${
-        overallVerdict === "PASS"
-          ? `The target system <strong>${escapeHtml(target.name)}</strong> <strong>passed all ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"}</strong> in the <em>${escapeHtml(metadata.configId)}</em> suite. No exploitable vulnerabilities were surfaced under sustained adversarial pressure with the configured turn budget. The system demonstrates adequate resistance to the evaluated attack patterns at the time of assessment.`
-          : `The target system <strong>${escapeHtml(target.name)}</strong> <strong>failed ${summary.failed} of ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"}</strong> (${summary.attackSuccessRate}% attack success rate) in the <em>${escapeHtml(metadata.configId)}</em> suite. ${summary.failed === 1 ? "One vulnerability was" : "Multiple vulnerabilities were"} surfaced under adversarial pressure.${criticalFindings.length > 0 ? ` <strong style="color:#DC2626">${criticalFindings.length} critical finding${criticalFindings.length === 1 ? "" : "s"}</strong> require immediate remediation.` : ""} Refer to the Findings section for a prioritised remediation plan.`
+        overallVerdict === "CANCELLED"
+          ? `<strong style="color:#D97706">⚠ Run cancelled by user.</strong> The assessment of <strong>${escapeHtml(target.name)}</strong> in the <em>${escapeHtml(metadata.configId)}</em> suite was stopped before all evaluators could complete. Of ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"} recorded, ${summary.passed} passed and ${summary.failed} failed${summary.cancelled ? `, and ${summary.cancelled} ${summary.cancelled === 1 ? "was" : "were"} interrupted mid-evaluation` : ""}. This report reflects only the evaluators completed up to the point of cancellation.`
+          : overallVerdict === "PASS"
+            ? `The target system <strong>${escapeHtml(target.name)}</strong> <strong>passed all ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"}</strong> in the <em>${escapeHtml(metadata.configId)}</em> suite. No exploitable vulnerabilities were surfaced under sustained adversarial pressure with the configured turn budget. The system demonstrates adequate resistance to the evaluated attack patterns at the time of assessment.`
+            : `The target system <strong>${escapeHtml(target.name)}</strong> <strong>failed ${summary.failed} of ${summary.totalTests} evaluator${summary.totalTests === 1 ? "" : "s"}</strong> (${summary.attackSuccessRate}% attack success rate) in the <em>${escapeHtml(metadata.configId)}</em> suite. ${summary.failed === 1 ? "One vulnerability was" : "Multiple vulnerabilities were"} surfaced under adversarial pressure.${criticalFindings.length > 0 ? ` <strong style="color:#DC2626">${criticalFindings.length} critical finding${criticalFindings.length === 1 ? "" : "s"}</strong> require immediate remediation.` : ""} Refer to the Findings section for a prioritised remediation plan.`
       }
     </div>
   </div>
@@ -1787,8 +1909,11 @@ async function setReportHistory(items) {
 
 async function addReportToHistory(report) {
   if (!report?.metadata?.reportId) return;
-  const verdict =
-    report?.summary?.failed === 0 && report?.summary?.totalTests > 0 ? "PASS" : "FAIL";
+  const verdict = report?.cancelled
+    ? "CANCELLED"
+    : report?.summary?.failed === 0 && report?.summary?.totalTests > 0
+      ? "PASS"
+      : "FAIL";
   const item = {
     id: report.metadata.reportId,
     generated: report.metadata.generated,
@@ -1864,10 +1989,13 @@ async function downloadReport() {
 
       if (opforLastResult?.judgment) {
         const verdict =
-          String(opforLastResult.judgment.verdict || "FAIL").toUpperCase() === "PASS"
-            ? "PASS"
-            : "FAIL";
-        const partialNote = opforLastResult.partial ? " (partial run)" : "";
+          opforLastResult.stopReason === "user_stop"
+            ? "CANCELLED"
+            : String(opforLastResult.judgment.verdict || "FAIL").toUpperCase() === "PASS"
+              ? "PASS"
+              : "FAIL";
+        const partialNote =
+          opforLastResult.partial && verdict !== "CANCELLED" ? " (partial run)" : "";
         state.results = [
           {
             id: opforLastResult.evaluatorId || "unknown",
@@ -1880,15 +2008,18 @@ async function downloadReport() {
         ];
       } else if (opforLastResult?.transcript?.length >= 2) {
         const turnCount = opforLastResult.transcript.length;
+        const wasCancelled = opforLastResult.stopReason === "user_stop";
         state.results = [
           {
             id: opforLastResult.evaluatorId || "unknown",
             name: opforLastResult.evaluatorName || "Evaluator",
             sev: normalizeSev(opforLastResult.severity),
-            verdict: "FAIL",
-            summary: opforLastResult.errorMessage
-              ? `Run failed after ${Math.floor(turnCount / 2)} turns: ${opforLastResult.errorMessage}`
-              : `Run ended with ${Math.floor(turnCount / 2)} turns but no judgment was produced.`,
+            verdict: wasCancelled ? "CANCELLED" : "FAIL",
+            summary: wasCancelled
+              ? `Cancelled by user after ${Math.floor(turnCount / 2)} turns.`
+              : opforLastResult.errorMessage
+                ? `Run failed after ${Math.floor(turnCount / 2)} turns: ${opforLastResult.errorMessage}`
+                : `Run ended with ${Math.floor(turnCount / 2)} turns but no judgment was produced.`,
             raw: opforLastResult,
           },
         ];
@@ -2035,15 +2166,19 @@ function renderHistoryList(items) {
     const id = item?.id || report?.metadata?.reportId || "";
     const cfg = item?.configId || report?.metadata?.configId || "";
     const sum = item?.summary || report?.summary || {};
-    const total = Number(sum.totalEvaluators ?? sum.totalTests ?? 0) || 0;
+    // Prefer the judged-only count (excludes cancelled evaluators) so a
+    // cancelled evaluator doesn't dilute the "X/Y passed" ratio; fall back
+    // to the raw total for reports persisted before this field existed.
+    const total = Number(sum.judged ?? sum.totalEvaluators ?? sum.totalTests ?? 0) || 0;
     const failed = Number(sum.failed ?? 0) || 0;
     const passed = Number(sum.passed ?? 0) || 0;
     const gen = item?.generated || report?.metadata?.generated || "";
     const allPassed = failed === 0 && total > 0;
+    const isCancelled = Boolean(item?.verdict === "CANCELLED" || report?.cancelled);
 
     const wrap = document.createElement("div");
     wrap.className = "history-item";
-    wrap.dataset.status = allPassed ? "pass" : "fail";
+    wrap.dataset.status = isCancelled ? "cancelled" : allPassed ? "pass" : "fail";
 
     const stripe = document.createElement("div");
     stripe.className = "accent-stripe";
@@ -2214,16 +2349,25 @@ async function runOneEvaluator(ev, { resume = false } = {}) {
       },
     };
   }
-  if (directResult?.paused) {
+  // `paused` means "interrupted, resumable snapshot saved"; `cancelled` means
+  // "interrupted, discarded". The background tags which one it was — never
+  // infer it here.
+  if (directResult?.paused || directResult?.cancelled) {
     stopCosmeticTicker();
-    return { paused: true, error: directResult.error };
+    return {
+      paused: !!directResult.paused,
+      cancelled: !!directResult.cancelled,
+      error: directResult.error,
+    };
   }
 
   // Otherwise poll storage — the service worker persists results there.
   const result = await pollStorageForResult(ev.id);
   stopCosmeticTicker();
 
-  if (result?.paused) return { paused: true, error: result.error };
+  if (result?.paused || result?.cancelled) {
+    return { paused: !!result.paused, cancelled: !!result.cancelled, error: result.error };
+  }
   if (!result?.ok) {
     const errMsg = result?.error || directResult?.error || "Unknown error";
     return { error: errMsg };
@@ -2232,18 +2376,54 @@ async function runOneEvaluator(ev, { resume = false } = {}) {
   setPhase("judging");
   await new Promise((r) => setTimeout(r, 250));
 
+  // A user-cancelled run is persisted with ok:true (it's a valid partial
+  // result, not an error) — never coerce that into PASS/FAIL. Key off
+  // stopReason, NOT `stopped`: a "recovered" partial is also flagged stopped
+  // but WAS genuinely judged, and must keep its real verdict.
   const verdict =
-    String(result.judgment?.verdict || "FAIL").toUpperCase() === "PASS" ? "PASS" : "FAIL";
+    result.stopReason === "user_stop"
+      ? "CANCELLED"
+      : String(result.judgment?.verdict || "FAIL").toUpperCase() === "PASS"
+        ? "PASS"
+        : "FAIL";
   return {
     record: {
       id: ev.id,
       name: ev.name,
       sev: ev.sev,
       verdict,
-      summary: result.judgment?.summary || "",
+      summary:
+        result.judgment?.summary ||
+        (verdict === "CANCELLED" ? "Cancelled by user before this evaluator could finish." : ""),
       raw: result,
     },
   };
+}
+
+/**
+ * Does a persisted record belong to the evaluator we're waiting on?
+ * Records written by a *previous* evaluator linger in storage, so anything
+ * read out of it must be ownership-checked before being treated as this
+ * evaluator's result. Records with no evaluatorId at all are accepted as a
+ * last resort (older writes, and error records the background couldn't tag).
+ */
+function matchesEvaluator(record, evaluatorId) {
+  if (!record) return false;
+  if (!record.evaluatorId) return true;
+  return record.evaluatorId === evaluatorId;
+}
+
+/**
+ * True once the user has asked to stop or pause.
+ *
+ * Judging a partial transcript is an LLM call, and it must never run in that
+ * case: a cancelled evaluator has no verdict to report, the call adds seconds
+ * to a stop the user wants immediate, and `OPFOR_JUDGE_PARTIAL` overwrites
+ * `opforLastResult` with `stopped: true` + real judge reasoning — which is how
+ * a cancelled row ended up carrying a full PASS/FAIL-style rationale.
+ */
+function userInterrupted() {
+  return state.cancelRequested || state.pauseRequested;
 }
 
 /**
@@ -2258,8 +2438,17 @@ async function pollStorageForResult(evaluatorId) {
   const pollStart = Date.now();
   let seenRunning = false;
 
+  // How long to keep waiting for the background's own stop/pause record after
+  // the user interrupts. The service worker flips run status to not-running
+  // the moment it receives the stop, well before the orchestrator has unwound
+  // and written its record — without this grace the poller would race past it.
+  const INTERRUPT_GRACE_MS = 12_000;
+  let interruptedAt = 0;
+
   while (Date.now() - pollStart < ABS_MAX_MS) {
     await new Promise((r) => setTimeout(r, POLL_MS));
+
+    if (userInterrupted() && !interruptedAt) interruptedAt = Date.now();
 
     let data;
     try {
@@ -2272,11 +2461,21 @@ async function pollStorageForResult(evaluatorId) {
       continue;
     }
 
-    // 1. Best case: completed result with judgment
-    const last = data.opforLastResult;
-    if (last?.judgment) {
-      if (last.evaluatorId === evaluatorId || last.completed) return last;
+    // 0. User interrupted: wait only for the background's own record, and
+    //    never fall through to the partial-judge steps below.
+    if (interruptedAt) {
+      const rec = data.opforLastResult;
+      if (rec && matchesEvaluator(rec, evaluatorId) && (rec.judgment || rec.stopReason)) return rec;
+      if (Date.now() - interruptedAt < INTERRUPT_GRACE_MS) continue;
+      return { paused: state.pauseRequested, cancelled: state.cancelRequested };
     }
+
+    // 1. Best case: completed result with judgment.
+    //    Must belong to THIS evaluator — a previous evaluator's `completed`
+    //    result left in storage would otherwise be returned immediately,
+    //    making this evaluator appear to finish instantly with its verdict.
+    const last = data.opforLastResult;
+    if (last?.judgment && matchesEvaluator(last, evaluatorId)) return last;
 
     const status = data.opforRunStatus;
 
@@ -2292,23 +2491,28 @@ async function pollStorageForResult(evaluatorId) {
       await new Promise((r) => setTimeout(r, 1500));
       try {
         const fresh = await chrome.storage.local.get(["opforLastResult"]);
-        if (fresh.opforLastResult?.judgment) return fresh.opforLastResult;
+        if (fresh.opforLastResult?.judgment && matchesEvaluator(fresh.opforLastResult, evaluatorId))
+          return fresh.opforLastResult;
       } catch {
         /* swallowed */
       }
     }
 
     // 4. Completed result with judgment (re-check after settle)
-    if (last?.judgment) return last;
+    if (last?.judgment && matchesEvaluator(last, evaluatorId)) return last;
 
     // 5. Service worker returned an explicit error (ok: false, no judgment)
-    if (last && last.ok === false && last.errorMessage) {
+    if (last && last.ok === false && last.errorMessage && matchesEvaluator(last, evaluatorId)) {
       return { ok: false, error: last.errorMessage };
     }
 
     // 6. Live transcript available — ask service worker to judge it
     const live = data.opforLiveTranscript;
-    if (live?.transcript?.length >= 2) {
+    if (
+      !userInterrupted() &&
+      live?.transcript?.length >= 2 &&
+      matchesEvaluator(live, evaluatorId)
+    ) {
       try {
         const judged = await chrome.runtime.sendMessage({
           type: "OPFOR_JUDGE_PARTIAL",
@@ -2354,12 +2558,17 @@ async function pollStorageForResult(evaluatorId) {
   // Final attempt
   try {
     const data = await chrome.storage.local.get(["opforLastResult", "opforLiveTranscript"]);
-    if (data.opforLastResult?.judgment) return data.opforLastResult;
-    if (data.opforLastResult?.errorMessage)
-      return { ok: false, error: data.opforLastResult.errorMessage };
+    const finalLast = data.opforLastResult;
+    if (finalLast?.judgment && matchesEvaluator(finalLast, evaluatorId)) return finalLast;
+    if (finalLast?.errorMessage && matchesEvaluator(finalLast, evaluatorId))
+      return { ok: false, error: finalLast.errorMessage };
 
     const live = data.opforLiveTranscript;
-    if (live?.transcript?.length >= 2) {
+    if (
+      !userInterrupted() &&
+      live?.transcript?.length >= 2 &&
+      matchesEvaluator(live, evaluatorId)
+    ) {
       try {
         const judged = await chrome.runtime.sendMessage({
           type: "OPFOR_JUDGE_PARTIAL",
@@ -2388,6 +2597,7 @@ async function startRun({ resume = false } = {}) {
   state.running = true;
   state.cancelRequested = false;
   state.pauseRequested = false;
+  state.runCancelled = false;
   state.lastReport = null;
   await saveModelAndKey();
 
@@ -2456,6 +2666,44 @@ async function startRun({ resume = false } = {}) {
     const out = await runOneEvaluator(ev, { resume: resume && isFirst });
     resume = false; // only resume the first evaluator on a resume
 
+    // The background reports ANY aborted turn as `paused: true` — it's the
+    // same generic signal for a real Pause and a user Stop. Only route to
+    // the resumable Paused screen when the user actually asked to pause;
+    // a Stop always means cancel-and-report, even if out.paused is set.
+    if (state.cancelRequested) {
+      let cancelledRecord = out.record || null;
+      if (!cancelledRecord) {
+        let opforLastResult = null;
+        try {
+          ({ opforLastResult } = await chrome.storage.local.get("opforLastResult"));
+        } catch {
+          /* swallowed */
+        }
+        const matches = opforLastResult?.evaluatorId === ev.id;
+        const j = matches ? opforLastResult.judgment : null;
+        cancelledRecord = {
+          id: ev.id,
+          name: ev.name,
+          sev: ev.sev,
+          verdict: "CANCELLED",
+          summary: j?.summary || "Cancelled by user before this evaluator could finish.",
+          raw: matches ? opforLastResult : null,
+        };
+      }
+      state.results.push(cancelledRecord);
+      state.evIdx++;
+      // A Stop always discards — never leave behind the resumable snapshot
+      // the background persists for ANY aborted turn (it can't tell Stop
+      // from Pause). Safe to do now: persistence happens before the
+      // background replies, so runOneEvaluator() resolving here guarantees
+      // it already wrote (or didn't write) whatever it was going to write.
+      try {
+        await chrome.runtime.sendMessage({ type: "OPFOR_UI_DISCARD_PAUSED" });
+      } catch {
+        /* swallowed */
+      }
+      break;
+    }
     if (state.pauseRequested || out.paused) {
       state.running = false;
       try {
@@ -2465,16 +2713,20 @@ async function startRun({ resume = false } = {}) {
       }
       state.keepAlivePort = null;
       stopCosmeticTicker();
-      await clearPopupRunQueue();
-      $("pausedSuite").textContent = state.suiteId;
-      $("pausedEvaluator").textContent = ev.name;
-      $("pausedModel").textContent = state.model;
-      $("pausedSub").textContent = `evaluator ${state.evIdx + 1} of ${state.queue.length} · saved`;
-      $("pausedElapsed").textContent = "—";
+      // Keep the queue — parked, not cleared. Clearing it here is why resuming
+      // used to drop every evaluator after the paused one: the popup could
+      // only rebuild a single-evaluator queue from the paused snapshot.
+      await persistPopupRunQueue({ running: false, paused: true });
+      let pausedRun = null;
+      try {
+        ({ opforPausedRun: pausedRun } = await chrome.storage.local.get("opforPausedRun"));
+      } catch {
+        /* swallowed */
+      }
+      renderPausedScreen(ev, pausedRun);
       setScreen("paused");
       return;
     }
-    if (state.cancelRequested) break;
     if (out.error) {
       let recovered = null;
       try {
@@ -2499,7 +2751,7 @@ async function startRun({ resume = false } = {}) {
             summary: opforLastResult.judgment.summary || "",
             raw: opforLastResult,
           };
-        } else if (live?.transcript?.length >= 2) {
+        } else if (!userInterrupted() && live?.transcript?.length >= 2) {
           try {
             const judged = await chrome.runtime.sendMessage({
               type: "OPFOR_JUDGE_PARTIAL",
@@ -2579,10 +2831,22 @@ async function startRun({ resume = false } = {}) {
   await clearPopupRunQueue();
 
   if (state.cancelRequested) {
-    state.queue = [];
-    state.results = [];
-    state.evIdx = 0;
-    setScreen("idle");
+    try {
+      await chrome.runtime.sendMessage({ type: "OPFOR_UI_DISCARD_PAUSED" });
+    } catch {
+      /* swallowed */
+    }
+    if (state.results.length) {
+      state.runCancelled = true;
+      await finalizeAndPersistCurrentReport();
+      renderDone();
+      setScreen("done");
+    } else {
+      state.queue = [];
+      state.results = [];
+      state.evIdx = 0;
+      setScreen("idle");
+    }
     return;
   }
 
@@ -2594,58 +2858,67 @@ async function startRun({ resume = false } = {}) {
 async function requestPause() {
   if (!state.running) return;
   state.pauseRequested = true;
+  setPauseBusy(true);
   stopRunStatusPoller();
-  await clearPopupRunQueue();
+  // Park the queue rather than clearing it — if the popup closes before the
+  // loop reaches its pause branch, the rest of the suite must still survive.
+  await persistPopupRunQueue({ running: false, paused: true });
   try {
-    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP" });
+    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP", intent: "pause" });
   } catch {
     /* swallowed */
   }
+
+  // Same reasoning as requestStop(): the still-running startRun() loop's
+  // in-flight runOneEvaluator() call will detect state.pauseRequested and
+  // transition to the resumable Paused screen once it resolves.
+  const phaseText = $("runPhaseText");
+  if (phaseText) phaseText.textContent = "Pausing — finishing current evaluator…";
 }
 
 async function requestStop() {
   state.cancelRequested = true;
   state.pauseRequested = false;
+  setStopBusy(true);
   stopRunStatusPoller();
   await clearPopupRunQueue();
   try {
-    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP" });
+    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP", intent: "cancel" });
   } catch {
     /* swallowed */
   }
 
-  // If the service worker saved a partial result, surface it on the Done screen.
-  try {
-    const { opforLastResult } = await chrome.storage.local.get("opforLastResult");
-    if (opforLastResult?.partial) {
-      const cur = state.queue[state.evIdx];
-      state.results.push({
-        id: cur?.id || "partial",
-        name: cur?.name || "Partial result",
-        sev: cur?.sev || "low",
-        verdict: "FAIL",
-        summary: "Stopped by user (partial result saved).",
-        raw: opforLastResult,
-      });
-      state.evIdx = Math.min(state.evIdx + 1, state.queue.length);
-      await finalizeAndPersistCurrentReport();
-      renderDone();
-      setScreen("done");
-      stopCosmeticTicker();
-      state.running = false;
-      return;
-    }
-  } catch {
-    /* swallowed */
+  // Give the user immediate feedback — the actual Cancelled report is
+  // finalized by the still-running startRun() loop once its in-flight
+  // runOneEvaluator() call resolves (guaranteed to happen: the background
+  // persists the partial result before it replies). Racing ahead to read
+  // storage here would only see it some of the time.
+  if (state.running) {
+    const phaseText = $("runPhaseText");
+    if (phaseText) phaseText.textContent = "Stopping — finishing current evaluator…";
+    return;
   }
 
+  // Nothing in flight — e.g. Stop pressed from the Paused screen. Discard the
+  // resumable snapshot and the parked queue, but still surface a report for
+  // whatever already completed rather than silently throwing it away.
   try {
     await chrome.runtime.sendMessage({ type: "OPFOR_UI_DISCARD_PAUSED" });
   } catch {
     /* swallowed */
   }
+  await clearPopupRunQueue();
   stopCosmeticTicker();
   state.running = false;
+
+  if (state.results.length) {
+    state.runCancelled = true;
+    await finalizeAndPersistCurrentReport();
+    renderDone();
+    setScreen("done");
+    return;
+  }
+
   state.queue = [];
   state.results = [];
   state.evIdx = 0;
@@ -2658,6 +2931,9 @@ async function discardPaused() {
   } catch {
     /* swallowed */
   }
+  // Drop the parked queue too, or the next popup open would offer to resume
+  // a run whose snapshot is already gone.
+  await clearPopupRunQueue();
   state.queue = [];
   state.results = [];
   state.evIdx = 0;
@@ -2665,11 +2941,24 @@ async function discardPaused() {
 }
 
 async function cancelAwaitUser() {
+  state.cancelRequested = true;
+  state.pauseRequested = false;
   try {
-    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP" });
+    await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP", intent: "cancel" });
   } catch {
     /* swallowed */
   }
+
+  // Same reasoning as requestStop(): the still-running startRun() loop's
+  // in-flight runOneEvaluator() call will detect the cancellation and
+  // finalize a Cancelled report once it resolves.
+  if (state.running) {
+    setScreen("running");
+    const phaseText = $("runPhaseText");
+    if (phaseText) phaseText.textContent = "Stopping — finishing current evaluator…";
+    return;
+  }
+
   stopCosmeticTicker();
   state.running = false;
   state.queue = [];
@@ -3063,11 +3352,12 @@ function wire() {
 // The popup drives the multi-evaluator loop but the service worker
 // clears opforRunStatus between evaluators. We persist the popup's
 // own queue state so reopening the popup mid-run shows progress.
-async function persistPopupRunQueue() {
+async function persistPopupRunQueue({ running = true, paused = false } = {}) {
   try {
     await chrome.storage.local.set({
       opforPopupRun: {
-        running: true,
+        running,
+        paused,
         suiteId: state.suiteId,
         queue: state.queue,
         evIdx: state.evIdx,
@@ -3183,9 +3473,14 @@ async function checkActiveRun() {
         lastAssistant = t.content;
       }
     }
-    latestTurn = { round: lastRound, user: lastUser, assistant: lastAssistant };
+    // Prefer the round the background actually reported. Deriving it from the
+    // transcript index undercounts a resumed run, whose stored transcript is
+    // capped at the most recent entries.
+    const reportedRound = Number(opforRunStatus?.lastRound) || 0;
+    const round = Math.max(reportedRound, lastRound);
+    latestTurn = { round, user: lastUser, assistant: lastAssistant };
     renderBubbles();
-    setTurnProgress(lastRound);
+    setTurnProgress(round);
   }
 
   startRunStatusPoller();

--- a/runners/extension/popup.js
+++ b/runners/extension/popup.js
@@ -112,6 +112,12 @@ const state = {
     /** @type {{id:string;name:string;sev:string;verdict:string;summary:string;raw:any}[]} */ ([]),
   lastReport: /** @type {any | null} */ (null),
   running: false,
+  // True only while THIS popup instance's startRun() loop is actively
+  // driving a run — as opposed to `running`, which also gets set to true
+  // when the popup reopens mid-run and merely restores the running screen
+  // from storage. Code that needs to know "is a loop here to notice a
+  // stop/pause request" must gate on this, not on `running`.
+  loopActive: false,
   cancelRequested: false,
   pauseRequested: false,
   // Set when the current/last completed run ended via user cancellation
@@ -150,14 +156,21 @@ function syncNav() {
 // Toggle a run-control button (Pause/Stop) into a disabled/loading state
 // while its request is in flight — both can take a few seconds to actually
 // resolve, since the popup waits on the in-flight evaluator to unwind.
-// Disables BOTH buttons regardless of which one is busy, so they can't race
-// each other; only the clicked button gets the spinner + label swap.
+// Stopping supersedes pausing, so Stop-busy also disables Pause. The reverse
+// does not hold: Pause-busy leaves Stop enabled, so the user can still
+// escalate a slow pause into a stop rather than being stuck with no escape
+// hatch — pause-to-cancel is a safe transition (the `intent` flag on the
+// last OPFOR_UI_STOP wins).
 function setRunControlBusy(prefix, busy, busyLabel) {
-  const stopBtn = $("stopBtn");
-  const pauseBtn = $("pauseBtn");
-  if (stopBtn) stopBtn.disabled = busy;
-  if (pauseBtn) pauseBtn.disabled = busy;
   const btn = $(prefix === "stop" ? "stopBtn" : "pauseBtn");
+  if (btn) btn.disabled = busy;
+  if (prefix === "stop") {
+    const pauseBtn = $("pauseBtn");
+    if (pauseBtn) pauseBtn.disabled = busy;
+    // Stop is also reachable from the Paused screen — keep it in sync.
+    const pausedStopBtn = $("pausedStopBtn");
+    if (pausedStopBtn) pausedStopBtn.disabled = busy;
+  }
   if (!btn) return;
   const icon = btn.querySelector(`.${prefix}-btn-icon`);
   const spinner = btn.querySelector(`.${prefix}-btn-spinner`);
@@ -996,11 +1009,12 @@ function renderDone() {
   const failed = state.results.filter((r) => r.verdict === "FAIL");
   const passed = state.results.filter((r) => r.verdict === "PASS");
   const cancelled = state.results.filter((r) => r.verdict === "CANCELLED");
-  const verdict = state.runCancelled
-    ? "CANCELLED"
-    : failed.length === 0 && state.results.length > 0
-      ? "PASS"
-      : "FAIL";
+  const verdict =
+    state.runCancelled || cancelled.length > 0
+      ? "CANCELLED"
+      : failed.length === 0 && state.results.length > 0
+        ? "PASS"
+        : "FAIL";
 
   const card = $("verdictCard");
   card.dataset.verdict = verdict;
@@ -1275,16 +1289,16 @@ function sevDot(sev) {
 
 function generateHtmlReport(report) {
   const { metadata, target, summary, evaluatorResults, criticalFindings, highFindings } = report;
-  const passPct = summary.totalTests ? Math.round((summary.passed / summary.totalTests) * 360) : 0;
-  const overallVerdict = report.cancelled
-    ? "CANCELLED"
-    : summary.failed === 0 && summary.totalTests > 0
-      ? "PASS"
-      : "FAIL";
   // Absent when nothing was judged — grading an unassessed run as "Critical
   // Risk" would be a fabricated conclusion, not a conservative default.
   const scored = summary.safetyScore != null;
   const judged = judgedCount(summary);
+  const overallVerdict =
+    report.cancelled || summary.cancelled > 0 || judged === 0
+      ? "CANCELLED"
+      : summary.failed === 0 && summary.totalTests > 0
+        ? "PASS"
+        : "FAIL";
   const riskLevel = !scored
     ? { label: "Not Assessed", color: "#64748B", bg: "#F1F5F9", border: "#CBD5E1" }
     : summary.safetyScore >= 80
@@ -1800,7 +1814,11 @@ function generateHtmlReport(report) {
             <div class="section-num">3</div>
             <div class="section-title">Key Findings</div>
           </div>
-          <div class="no-findings">No critical or high severity findings — system passed all evaluated attack patterns.</div>
+          <div class="no-findings">${
+            judged === 0
+              ? "No critical or high severity findings — no evaluator was assessed before the run was cancelled."
+              : "No critical or high severity findings — system passed all evaluated attack patterns."
+          }</div>
         </div>`
   }
 
@@ -2018,6 +2036,7 @@ async function downloadReport() {
               : "FAIL";
         const partialNote =
           opforLastResult.partial && verdict !== "CANCELLED" ? " (partial run)" : "";
+        if (verdict === "CANCELLED") state.runCancelled = true;
         state.results = [
           {
             id: opforLastResult.evaluatorId || "unknown",
@@ -2031,6 +2050,7 @@ async function downloadReport() {
       } else if (opforLastResult?.transcript?.length >= 2) {
         const turnCount = opforLastResult.transcript.length;
         const wasCancelled = opforLastResult.stopReason === "user_stop";
+        if (wasCancelled) state.runCancelled = true;
         state.results = [
           {
             id: opforLastResult.evaluatorId || "unknown",
@@ -2476,6 +2496,7 @@ async function pollStorageForResult(evaluatorId) {
         "opforLastResult",
         "opforLiveTranscript",
         "opforRunStatus",
+        "opforPausedRun",
       ]);
     } catch {
       continue;
@@ -2486,6 +2507,12 @@ async function pollStorageForResult(evaluatorId) {
     if (interruptedAt) {
       const rec = data.opforLastResult;
       if (rec && matchesEvaluator(rec, evaluatorId) && (rec.judgment || rec.stopReason)) return rec;
+      // A pause writes no `opforLastResult` by design — the snapshot is the
+      // only signal that it landed. Compare against `interruptedAt` so a
+      // stale snapshot from an earlier pause can't resolve this one early.
+      if (state.pauseRequested && Number(data.opforPausedRun?.savedAt) >= interruptedAt) {
+        return { paused: true };
+      }
       if (Date.now() - interruptedAt < INTERRUPT_GRACE_MS) continue;
       return { paused: state.pauseRequested, cancelled: state.cancelRequested };
     }
@@ -2615,6 +2642,7 @@ async function pollStorageForResult(evaluatorId) {
 async function startRun({ resume = false } = {}) {
   if (state.running) return;
   state.running = true;
+  state.loopActive = true;
   state.cancelRequested = false;
   state.pauseRequested = false;
   state.runCancelled = false;
@@ -2627,6 +2655,7 @@ async function startRun({ resume = false } = {}) {
     const suite = state.catalog?.suites.find((s) => s.id === state.suiteId);
     if (!suite) {
       state.running = false;
+      state.loopActive = false;
       return;
     }
     const byId = new Map(state.catalog.evaluators.map((e) => [e.id, e]));
@@ -2726,6 +2755,7 @@ async function startRun({ resume = false } = {}) {
     }
     if (state.pauseRequested || out.paused) {
       state.running = false;
+      state.loopActive = false;
       try {
         state.keepAlivePort?.disconnect();
       } catch {
@@ -2839,6 +2869,7 @@ async function startRun({ resume = false } = {}) {
   }
 
   state.running = false;
+  state.loopActive = false;
   state.targetTabId = null;
   try {
     state.keepAlivePort?.disconnect();
@@ -2900,7 +2931,13 @@ async function requestStop() {
   state.cancelRequested = true;
   state.pauseRequested = false;
   setStopBusy(true);
-  stopRunStatusPoller();
+  // Only stop the poller when OUR OWN startRun() loop is driving this run —
+  // it will handle the transition itself once its in-flight call resolves.
+  // If the loop isn't ours (popup was reopened mid-run), the poller is the
+  // only thing that will ever notice the background's stop; killing it here
+  // would leave the run permanently stuck (see the loopActive check below).
+  const ownedByLoop = state.loopActive;
+  if (ownedByLoop) stopRunStatusPoller();
   await clearPopupRunQueue();
   try {
     await chrome.runtime.sendMessage({ type: "OPFOR_UI_STOP", intent: "cancel" });
@@ -2913,6 +2950,16 @@ async function requestStop() {
   // runOneEvaluator() call resolves (guaranteed to happen: the background
   // persists the partial result before it replies). Racing ahead to read
   // storage here would only see it some of the time.
+  if (ownedByLoop) {
+    const phaseText = $("runPhaseText");
+    if (phaseText) phaseText.textContent = "Stopping — finishing current evaluator…";
+    return;
+  }
+
+  // The popup was reopened mid-run: `state.running` mirrors storage, but
+  // there is no local loop to notice the stop. The run-status poller (left
+  // running above) will detect the background's own terminal record and
+  // finalize the report itself once it lands.
   if (state.running) {
     const phaseText = $("runPhaseText");
     if (phaseText) phaseText.textContent = "Stopping — finishing current evaluator…";
@@ -3312,6 +3359,7 @@ function wire() {
   $("stopBtn").addEventListener("click", requestStop);
   $("resumeBtn").addEventListener("click", () => startRun({ resume: true }));
   $("discardPausedBtn").addEventListener("click", discardPaused);
+  $("pausedStopBtn").addEventListener("click", requestStop);
   $("awaitUserCancelBtn").addEventListener("click", cancelAwaitUser);
   $("awaitUserRetryBtn").addEventListener("click", retryLocate);
   $("newRunBtn").addEventListener("click", () => {
@@ -3553,35 +3601,59 @@ function startRunStatusPoller() {
       }
 
       // The service worker clears running=false after each evaluator finishes.
-      // If the popup's own startRun loop is still active (state.running === true),
-      // it means more evaluators are queued — don't jump to idle/done.
+      // If a real startRun() loop owns this run (state.loopActive), it's
+      // already handling the transition to the next evaluator or the final
+      // Done screen — don't preempt it. If there is no such loop (the popup
+      // was reopened mid-run, or the owning popup instance closed), this is
+      // the only thing left that will ever notice the run ended, so finalize
+      // it here.
       if (!opforRunStatus.running) {
-        if (state.running) return;
+        if (state.loopActive) return;
         stopRunStatusPoller();
         stopCosmeticTicker();
         const hasPaused = await checkPausedRun();
         if (!hasPaused) {
           const { opforLastResult } = await chrome.storage.local.get("opforLastResult");
-          if (opforLastResult && !opforLastResult.partial) {
+          const cur = state.queue[state.evIdx] || state.queue[0];
+          if (opforLastResult && matchesEvaluator(opforLastResult, cur?.id)) {
             const verdict =
-              String(opforLastResult.judgment?.verdict || "FAIL").toUpperCase() === "PASS"
-                ? "PASS"
-                : "FAIL";
-            state.results = [
-              {
-                id: opforLastResult.evaluatorId || state.queue[0]?.id || "",
-                name: opforLastResult.evaluatorName || state.queue[0]?.name || "",
-                sev: state.queue[0]?.sev || "low",
+              opforLastResult.stopReason === "user_stop"
+                ? "CANCELLED"
+                : opforLastResult.judgment
+                  ? String(opforLastResult.judgment.verdict || "FAIL").toUpperCase() === "PASS"
+                    ? "PASS"
+                    : "FAIL"
+                  : null;
+            // `null` means the evaluator neither completed nor was cancelled
+            // (e.g. a bare error record) — nothing to add to the report.
+            if (verdict) {
+              state.results.push({
+                id: opforLastResult.evaluatorId || cur?.id || "",
+                name: opforLastResult.evaluatorName || cur?.name || "",
+                sev: cur?.sev || "low",
                 verdict,
-                summary: opforLastResult.judgment?.summary || "",
+                summary:
+                  opforLastResult.judgment?.summary ||
+                  (verdict === "CANCELLED"
+                    ? "Cancelled by user before this evaluator could finish."
+                    : ""),
                 raw: opforLastResult,
-              },
-            ];
-            state.evIdx = 1;
+              });
+              state.evIdx++;
+            }
+          }
+          state.running = false;
+          await clearPopupRunQueue();
+          if (state.results.length) {
+            // No loop is left to run whatever's still queued — the suite
+            // ends here, same as a user-initiated stop.
+            if (state.evIdx < state.queue.length) state.runCancelled = true;
             await finalizeAndPersistCurrentReport();
             renderDone();
             setScreen("done");
           } else {
+            state.queue = [];
+            state.evIdx = 0;
             setScreen("idle");
           }
         }

--- a/runners/extension/service_worker.js
+++ b/runners/extension/service_worker.js
@@ -71,6 +71,7 @@ function adaptJudgeResult(coreResult) {
 function handleMainMessages(message, sendResponse) {
   if (message?.type === "OPFOR_UI_STOP") {
     state.OPFOR_STOP = true;
+    state.OPFOR_STOP_INTENT = message.intent === "pause" ? "pause" : "cancel";
     try {
       state.uiRunAbortController?.abort();
     } catch {

--- a/runners/extension/state.js
+++ b/runners/extension/state.js
@@ -1,6 +1,11 @@
 // Shared mutable run state. Use the object reference so all modules see live values.
 export const state = {
   OPFOR_STOP: false,
+  // "pause" (resumable) or "cancel" (discard) — set from the OPFOR_UI_STOP
+  // message so orchestrator.js knows whether to persist a resumable
+  // snapshot. Defaults to "cancel" so an unspecified/legacy stop never
+  // leaves behind a resumable run the user never asked to keep.
+  OPFOR_STOP_INTENT: "cancel",
   uiRunAbortController: null,
   retryLocateResolver: null,
 };


### PR DESCRIPTION
## Problem

Stopping a run in the browser extension left the user with nothing useful:

- **Cancelling discarded everything.** Clicking Stop between evaluators wiped the queue and dropped back to the idle screen — no report, no record of the evaluators that had already completed.
- **Cancelled evaluators were reported as `FAIL`.** When a partial result did survive, it was hardcoded to `FAIL`, so a run the user interrupted was indistinguishable from a genuine vulnerability.
- **Cancelling still ran the LLM judge.** The interrupted evaluator was judged on its partial transcript, which added seconds to a stop the user wanted immediate and produced a full PASS/FAIL-style rationale, score, and confidence for a turn the target never finished.
- **Cancelled evaluators diluted the safety score.** They contributed their severity weight to the denominator but never to the numerator, so 1 pass + 1 cancelled scored well under 100%.
- **Pause and Stop were indistinguishable.** Both arrive as the same `OPFOR_STOP` signal, and the stop handler did both things at once — wrote a terminal `CANCELLED` result *and* saved a resumable snapshot. Everything downstream then guessed, and guessed inconsistently:
  - A merely-paused evaluator surfaced as `CANCELLED` in the report.
  - A genuine Stop still left a resumable snapshot, so reopening the extension offered a stale "Run paused / Resume" screen.
  - Resuming showed no progress (0 turns) and restarted the turn counter at 1.
  - Resuming after closing the popup dropped every evaluator after the paused one.
  - A previous evaluator's `completed` result could resolve the *next* evaluator instantly, with the wrong verdict.
- **No feedback on Pause/Stop.** Both take a few seconds while the in-flight evaluator unwinds, with no indication anything happened — Pause in particular looked broken.

## Solution

Make cancellation a real, first-class outcome, and give Pause and Stop opposite, explicit contracts.

**Cancellation is its own state.** A new `CANCELLED` verdict sits alongside `PASS`/`FAIL`, styled with the existing amber `--warn` token — same card, pill, and banner layout, only a third colour. Cancelling now always produces a report of the evaluators completed up to that point.

**Never judge what was cancelled.** The judge call is skipped entirely on cancel. Because an unfinished evaluator has no verdict, no score, confidence, or reasoning is fabricated for it — the report shows `—` rather than a plausible-looking number.

**Pause and Stop carry explicit intent.** The popup tags the `OPFOR_UI_STOP` message with `intent: "pause" | "cancel"`, and a single `finalizeUserInterruption()` helper in the background enforces the split, so the two can't drift apart:

| | resumable snapshot | terminal result |
|---|---|---|
| **Pause** | ✅ saved | ❌ none — an unfinished evaluator has no verdict |
| **Stop** | ❌ removed | ✅ `CANCELLED` |

The reply carries the intent back, so the popup never infers pause-vs-cancel from the ambiguous `paused` flag.

## Changes

All in `runners/extension/` — no core or CLI changes.

| File | What changed |
|---|---|
| `orchestrator.js` | Added `finalizeUserInterruption()` + `cancelledJudgment()`; both stop paths route through them. Removed the judge call on stop (and the now-unused `judgeResponse` import). Carry the restored transcript and `resumedFromRound` through `setRunStatus` on resume instead of writing `[]`. Clear `opforLastResult` at the start of every run, including resume. Degrade an unresumable pause to a cancel. |
| `popup.js` | `CANCELLED` verdict throughout `renderDone`, `buildReport`, `generateHtmlReport`, and run history. Exclude cancelled evaluators from the weighted score and add a `judged` count. `null` score/confidence for cancelled rows. Added `userInterrupted()` and guarded all three `OPFOR_JUDGE_PARTIAL` call sites. Added a fast interrupt path to the storage poller. Ownership-check persisted records via `matchesEvaluator()`. Park the queue on pause instead of clearing it; restore the full queue in `checkPausedRun`. Added `renderPausedScreen()` and `setPauseBusy`/`setStopBusy`. |
| `popup.html` | `CANCELLED` styling for the verdict card, result rows/pills, and history stripe. Spinner + label markup for Pause/Stop, `:disabled` styles, and fixed-width labels so the icon doesn't shift when the label swaps. |
| `service_worker.js` | Record `state.OPFOR_STOP_INTENT` from the stop message. |
| `state.js` | New `OPFOR_STOP_INTENT` field, defaulting to `"cancel"` so an untagged stop never leaves a resumable run behind. |
| `domTarget.js` | New `roundOffset` option so round numbers continue after a resume rather than restarting at 1. |

### Notable bug found along the way

The verdict check keyed off `result.stopped`, but `stopped: true` is *also* set on legitimately-judged `"recovered"` partials — so runs recovered after an interruption were being mislabelled `CANCELLED` and losing their real verdict. All three sites now key off `stopReason === "user_stop"`.

## Issue

N/A

## How to test

`popup.js` / `popup.html` are loaded directly by the manifest, so no build step is needed — but the background service worker **does** need a full reload: `chrome://extensions` → reload icon. Reopening the popup alone is not enough.

**Cancel produces a report**
1. Start a suite with 2–3 evaluators. Let the first finish, then click **Stop** mid-way through the second.
2. Stop shows a spinner and "Stopping…" immediately, with the icon staying put (no left-shift), and resolves in about a second — no judge call.
3. The done screen shows aggregate **CANCELLED** in amber, the completed evaluator with its real verdict, and the interrupted one as `CANCELLED`.
4. The interrupted row shows `—` for score and confidence, and reads "Cancelled by user before this evaluator could finish." — *not* an LLM rationale.
5. Safety Score reads "Based on 1 evaluator · 1 cancelled" and is not diluted by the cancelled one.
6. Download the report — the same states appear in the exported HTML.

**Stop does not leave a resumable run**
7. Close and reopen the extension. It should return to idle — **not** a "Run paused / Resume" screen.

**Pause and resume**
8. Start a 3-evaluator suite. Let the first finish, click **Pause** during the second.
9. Pause shows its own spinner and "Pausing…", then the paused screen reports real progress, e.g. `evaluator 2 of 3 · 3 of 10 turns done · saved`.
10. **Close and reopen the popup**, then click **Resume**.
11. The running screen shows the prior turn count (not 0) and the counter continues (e.g. turn 4), rather than restarting at 1.
12. The run continues through evaluator 3 — the rest of the suite is not dropped.
13. The final report shows the paused evaluator with its **real PASS/FAIL** verdict, never `CANCELLED`, and no evaluator resolves instantly with a previous evaluator's verdict.

**Edge cases**
14. Pause, then click **Stop** from the paused screen → a `CANCELLED` report of what completed, and no resumable run on reopen.
15. Pause, then **Discard** → idle, with no resumable run offered on reopen.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distinct Pause vs Cancel handling for evaluator runs, including a persisted stop intent.
  * Cancelled runs now show a clear **CANCELLED** state across the UI, reports, and history, with dedicated styling.
  * Cancelled evaluators are excluded from safety/attack scoring and have `confidence` cleared in outputs.
  * Paused runs can resume with aligned round numbering and restored queue context.

* **Bug Fixes**
  * Improved interruption finalization and resume/stop semantics to prevent inconsistent outcomes.
  * Reduced background polling race conditions and corrected cancelled vs paused verdict reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->